### PR TITLE
[FEAT] 행사 상세 조회 기능

### DIFF
--- a/src/main/java/com/efub/dhs/domain/heart/repository/HeartRepository.java
+++ b/src/main/java/com/efub/dhs/domain/heart/repository/HeartRepository.java
@@ -1,0 +1,16 @@
+package com.efub.dhs.domain.heart.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.efub.dhs.domain.heart.entity.Heart;
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.program.entity.Program;
+
+public interface HeartRepository extends JpaRepository<Heart, Long> {
+
+	Boolean existsByMemberAndProgram(Member member, Program program);
+
+	Optional<Heart> findByMemberAndProgram(Member member, Program program);
+}

--- a/src/main/java/com/efub/dhs/domain/heart/service/HeartService.java
+++ b/src/main/java/com/efub/dhs/domain/heart/service/HeartService.java
@@ -1,0 +1,30 @@
+package com.efub.dhs.domain.heart.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.efub.dhs.domain.heart.entity.Heart;
+import com.efub.dhs.domain.heart.repository.HeartRepository;
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.program.entity.Program;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class HeartService {
+
+	private final HeartRepository heartRepository;
+
+	@Transactional(readOnly = true)
+	public Boolean existsByMemberAndProgram(Member member, Program program) {
+		if (heartRepository.existsByMemberAndProgram(member, program)) {
+			Heart heart = heartRepository.findByMemberAndProgram(member, program)
+				.orElseThrow(() -> new IllegalArgumentException("이 회원은 이 행사를 신청하지 않았습니다."));
+			return heart.getExist();
+		} else {
+			return false;
+		}
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -1,0 +1,27 @@
+package com.efub.dhs.domain.program.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.efub.dhs.domain.program.dto.ProgramDetailResponseDto;
+import com.efub.dhs.domain.program.service.ProgramService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/programs")
+public class ProgramController {
+
+	private final ProgramService programService;
+
+	@GetMapping("/{programId}")
+	@ResponseStatus(value = HttpStatus.OK)
+	public ProgramDetailResponseDto programFind(@PathVariable Long programId) {
+		return programService.findProgramById(programId);
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/GoalDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/GoalDto.java
@@ -1,0 +1,19 @@
+package com.efub.dhs.domain.program.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoalDto {
+	private Integer targetNumber;
+	private Integer registrantNumber;
+	private Double progressRate;
+
+	public GoalDto(Integer targetNumber, Integer registrantNumber, Double progressRate) {
+		this.targetNumber = targetNumber;
+		this.registrantNumber = registrantNumber;
+		this.progressRate = progressRate;
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/HostDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/HostDto.java
@@ -1,0 +1,17 @@
+package com.efub.dhs.domain.program.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HostDto {
+	private String name;
+	private String description;
+
+	public HostDto(String name, String description) {
+		this.name = name;
+		this.description = description;
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/ImageDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/ImageDto.java
@@ -1,0 +1,19 @@
+package com.efub.dhs.domain.program.dto;
+
+import com.efub.dhs.domain.program.entity.ProgramImage;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageDto {
+	private Long id;
+	private String url;
+
+	public ImageDto(ProgramImage image) {
+		this.id = image.getImageId();
+		this.url = image.getUrl();
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/NoticeDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/NoticeDto.java
@@ -1,0 +1,25 @@
+package com.efub.dhs.domain.program.dto;
+
+import java.time.LocalDateTime;
+
+import com.efub.dhs.domain.program.entity.Notice;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeDto {
+	private Long noticeId;
+	private String title;
+	private String content;
+	private LocalDateTime createdDate;
+
+	public NoticeDto(Notice notice) {
+		this.noticeId = notice.getNoticeId();
+		this.title = notice.getTitle();
+		this.content = notice.getContent();
+		this.createdDate = notice.getCreatedDate();
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/ProgramDetailResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/ProgramDetailResponseDto.java
@@ -1,0 +1,22 @@
+package com.efub.dhs.domain.program.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProgramDetailResponseDto {
+	private ProgramDto program;
+	private ProgramMemberDto member;
+	private List<ProgramOutlineResponseDto> otherPrograms;
+
+	public ProgramDetailResponseDto(ProgramDto program, ProgramMemberDto member,
+		List<ProgramOutlineResponseDto> otherPrograms) {
+		this.program = program;
+		this.member = member;
+		this.otherPrograms = otherPrograms;
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/ProgramDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/ProgramDto.java
@@ -16,7 +16,6 @@ public class ProgramDto {
 	private Long programId;
 	private String title;
 	private Category category;
-	private String thumbnailImage;
 	private LocalDateTime schedule;
 	private String postalCode;
 	private String location;
@@ -37,7 +36,6 @@ public class ProgramDto {
 		this.programId = program.getProgramId();
 		this.title = program.getTitle();
 		this.category = program.getCategory();
-		this.thumbnailImage = program.getThumbnailImage();
 		this.schedule = program.getSchedule();
 		this.postalCode = program.getPostalCode();
 		this.location = program.getLocation();

--- a/src/main/java/com/efub/dhs/domain/program/dto/ProgramDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/ProgramDto.java
@@ -1,0 +1,56 @@
+package com.efub.dhs.domain.program.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.efub.dhs.domain.program.entity.Category;
+import com.efub.dhs.domain.program.entity.Program;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProgramDto {
+	private Long programId;
+	private String title;
+	private Category category;
+	private String thumbnailImage;
+	private LocalDateTime schedule;
+	private String postalCode;
+	private String location;
+	private LocalDateTime deadline;
+	private Integer remainingDays;
+	private Boolean isOpen;
+	private GoalDto goal;
+	private Long likeNumber;
+	private String content;
+	private List<ImageDto> contentImages;
+	private String depositInfo;
+	private String price;
+	private List<NoticeDto> notices;
+	private HostDto host;
+
+	public ProgramDto(Program program, Integer remainingDays, GoalDto goal, List<ImageDto> contentImages,
+		String depositInfo, List<NoticeDto> notices, HostDto host) {
+		this.programId = program.getProgramId();
+		this.title = program.getTitle();
+		this.category = program.getCategory();
+		this.thumbnailImage = program.getThumbnailImage();
+		this.schedule = program.getSchedule();
+		this.postalCode = program.getPostalCode();
+		this.location = program.getLocation();
+		this.deadline = program.getDeadline();
+		this.remainingDays = remainingDays;
+		this.isOpen = program.getIsOpen();
+		this.goal = goal;
+		this.likeNumber = program.getLikeNumber();
+		this.content = program.getContent();
+		this.contentImages = contentImages;
+		this.depositInfo = depositInfo;
+		this.price = program.getPrice();
+		this.notices = notices;
+		this.host = host;
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/ProgramMemberDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/ProgramMemberDto.java
@@ -7,11 +7,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProgramMemberDto {
-	private boolean hasLike;
-	private boolean hasRegistration;
+	private Boolean hasLike;
+	private Boolean hasRegistration;
+	private Boolean isHost;
 
-	public ProgramMemberDto(Boolean hasLike, Boolean hasRegistration) {
+	public ProgramMemberDto(Boolean hasLike, Boolean hasRegistration, Boolean isHost) {
 		this.hasLike = hasLike;
 		this.hasRegistration = hasRegistration;
+		this.isHost = isHost;
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/dto/ProgramMemberDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/ProgramMemberDto.java
@@ -1,0 +1,17 @@
+package com.efub.dhs.domain.program.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProgramMemberDto {
+	private boolean hasLike;
+	private boolean hasRegistration;
+
+	public ProgramMemberDto(Boolean hasLike, Boolean hasRegistration) {
+		this.hasLike = hasLike;
+		this.hasRegistration = hasRegistration;
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/ProgramOutlineResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/ProgramOutlineResponseDto.java
@@ -24,7 +24,7 @@ public class ProgramOutlineResponseDto {
 		this.programId = program.getProgramId();
 		this.title = program.getTitle();
 		this.category = program.getCategory();
-		this.thumbnailImage = program.getThumbnailImage();
+		this.thumbnailImage = program.getImages().get(0).getUrl();
 		this.remainingDays = remainingDays;
 		this.isOpen = program.getIsOpen();
 		this.goal = goal;

--- a/src/main/java/com/efub/dhs/domain/program/dto/ProgramOutlineResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/ProgramOutlineResponseDto.java
@@ -1,0 +1,34 @@
+package com.efub.dhs.domain.program.dto;
+
+import com.efub.dhs.domain.program.entity.Category;
+import com.efub.dhs.domain.program.entity.Program;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProgramOutlineResponseDto {
+	private Long programId;
+	private String title;
+	private Category category;
+	private String thumbnailImage;
+	private Integer remainingDays;
+	private Boolean isOpen;
+	private GoalDto goal;
+	private String content;
+	private Boolean hasLike;
+
+	public ProgramOutlineResponseDto(Program program, Integer remainingDays, GoalDto goal, Boolean hasLike) {
+		this.programId = program.getProgramId();
+		this.title = program.getTitle();
+		this.category = program.getCategory();
+		this.thumbnailImage = program.getThumbnailImage();
+		this.remainingDays = remainingDays;
+		this.isOpen = program.getIsOpen();
+		this.goal = goal;
+		this.content = program.getContent();
+		this.hasLike = hasLike;
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/entity/Program.java
+++ b/src/main/java/com/efub/dhs/domain/program/entity/Program.java
@@ -37,9 +37,6 @@ public class Program extends BaseTimeEntity {
 	@Column(nullable = false, length = 50)
 	private String title;
 
-	@Column(name = "thumbnail_image", nullable = false)
-	private String thumbnailImage;
-
 	@Enumerated(value = EnumType.STRING)
 	@Column(nullable = false)
 	private Category category;
@@ -96,14 +93,13 @@ public class Program extends BaseTimeEntity {
 	private List<Notice> notices;
 
 	@Builder
-	public Program(Member host, String title, String thumbnailImage, Category category,
+	public Program(Member host, String title, Category category,
 		LocalDateTime schedule, String location, String postalCode, LocalDateTime deadline,
 		Boolean isOpen, Integer targetNumber, String content, String depositBank,
 		String depositName, String depositAccount, String price, String hostName,
 		String hostDescription, List<ProgramImage> images, List<Notice> notices) {
 		this.host = host;
 		this.title = title;
-		this.thumbnailImage = thumbnailImage;
 		this.category = category;
 		this.schedule = schedule;
 		this.location = location;

--- a/src/main/java/com/efub/dhs/domain/program/repository/NoticeRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/NoticeRepository.java
@@ -1,0 +1,12 @@
+package com.efub.dhs.domain.program.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.efub.dhs.domain.program.entity.Notice;
+import com.efub.dhs.domain.program.entity.Program;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+	List<Notice> findAllByProgram(Program program);
+}

--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramImageRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramImageRepository.java
@@ -1,0 +1,13 @@
+package com.efub.dhs.domain.program.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.program.entity.ProgramImage;
+
+public interface ProgramImageRepository extends JpaRepository<ProgramImage, Long> {
+
+	List<ProgramImage> findAllByProgram(Program program);
+}

--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
@@ -1,0 +1,14 @@
+package com.efub.dhs.domain.program.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.efub.dhs.domain.program.entity.Category;
+import com.efub.dhs.domain.program.entity.Program;
+
+public interface ProgramRepository extends JpaRepository<Program, Long> {
+
+	//List<Program> findTop3ByCategoryAndScheduleMonth(Category category, Month month);
+	List<Program> findTop3ByCategory(Category category);
+}

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -1,0 +1,113 @@
+package com.efub.dhs.domain.program.service;
+
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.efub.dhs.domain.heart.service.HeartService;
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.member.repository.MemberRepository;
+import com.efub.dhs.domain.program.dto.GoalDto;
+import com.efub.dhs.domain.program.dto.HostDto;
+import com.efub.dhs.domain.program.dto.ImageDto;
+import com.efub.dhs.domain.program.dto.NoticeDto;
+import com.efub.dhs.domain.program.dto.ProgramDetailResponseDto;
+import com.efub.dhs.domain.program.dto.ProgramDto;
+import com.efub.dhs.domain.program.dto.ProgramMemberDto;
+import com.efub.dhs.domain.program.dto.ProgramOutlineResponseDto;
+import com.efub.dhs.domain.program.entity.Notice;
+import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.program.entity.ProgramImage;
+import com.efub.dhs.domain.program.repository.NoticeRepository;
+import com.efub.dhs.domain.program.repository.ProgramImageRepository;
+import com.efub.dhs.domain.program.repository.ProgramRepository;
+import com.efub.dhs.domain.registration.service.RegistrationService;
+import com.efub.dhs.global.utils.SecurityUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProgramService {
+
+	private final ProgramRepository programRepository;
+	private final ProgramImageRepository programImageRepository;
+	private final NoticeRepository noticeRepository;
+	private final MemberRepository memberRepository;
+	private final HeartService heartService;
+	private final RegistrationService registrationService;
+
+	public ProgramDetailResponseDto findProgramById(Long programId) {
+		Program program = programRepository.findById(programId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 행사를 찾을 수 없습니다."));
+
+		String username = SecurityUtils.getCurrentUsername();
+		Member member = memberRepository.findByUsername(username)
+			.orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원을 찾을 수 없습니다."));
+
+		Integer remainingDays = calculateRemainingDays(program.getDeadline());
+
+		GoalDto goal = findGoalByProgram(program.getTargetNumber(), program.getRegistrantNumber());
+
+		return new ProgramDetailResponseDto(
+			findProgramInfo(program, remainingDays, goal),
+			findProgramMemberInfo(program, member),
+			findSimilarPrograms(program, member)
+		);
+	}
+
+	public Integer calculateRemainingDays(LocalDateTime deadline) {
+		return Period.between(LocalDateTime.now().toLocalDate(), deadline.toLocalDate()).getDays();
+	}
+
+	public GoalDto findGoalByProgram(Integer targetNumber, Integer registrantNumber) {
+		Double progressRate = registrantNumber.doubleValue() / targetNumber.doubleValue() * 100;
+		return new GoalDto(targetNumber, registrantNumber, progressRate);
+	}
+
+	public List<ImageDto> findProgramImagesByProgram(Program program) {
+		List<ProgramImage> programImages = programImageRepository.findAllByProgram(program);
+		return programImages.stream().map(ImageDto::new).collect(Collectors.toList());
+	}
+
+	public List<NoticeDto> findNoticesByProgram(Program program) {
+		List<Notice> notices = noticeRepository.findAllByProgram(program);
+		return notices.stream().map(NoticeDto::new).collect(Collectors.toList());
+	}
+
+	public ProgramDto findProgramInfo(Program program, Integer remainingDays, GoalDto goal) {
+		List<ImageDto> contentImages = findProgramImagesByProgram(program);
+
+		List<NoticeDto> notices = findNoticesByProgram(program);
+
+		String depositInfo =
+			program.getDepositBank() + " " + program.getDepositAccount() + " " + program.getDepositName();
+
+		HostDto host = new HostDto(program.getHostName(), program.getHostDescription());
+
+		return new ProgramDto(program, remainingDays, goal, contentImages, depositInfo, notices, host);
+	}
+
+	public ProgramMemberDto findProgramMemberInfo(Program program, Member member) {
+		Boolean hasLike = heartService.existsByMemberAndProgram(member, program);
+		Boolean hasRegistration = registrationService.existsByMemberAndProgram(member, program);
+		return new ProgramMemberDto(hasLike, hasRegistration);
+	}
+
+	public List<ProgramOutlineResponseDto> findSimilarPrograms(Program program, Member member) {
+		List<Program> similarPrograms =
+			programRepository.findTop3ByCategory(program.getCategory());
+
+		return similarPrograms.stream().map(similarProgram ->
+			new ProgramOutlineResponseDto(similarProgram,
+				calculateRemainingDays(similarProgram.getDeadline()),
+				findGoalByProgram(similarProgram.getTargetNumber(), similarProgram.getRegistrantNumber()),
+				heartService.existsByMemberAndProgram(member, program))
+		).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -96,7 +96,8 @@ public class ProgramService {
 	public ProgramMemberDto findProgramMemberInfo(Program program, Member member) {
 		Boolean hasLike = heartService.existsByMemberAndProgram(member, program);
 		Boolean hasRegistration = registrationService.existsByMemberAndProgram(member, program);
-		return new ProgramMemberDto(hasLike, hasRegistration);
+		Boolean isHost = program.getHost().equals(member);
+		return new ProgramMemberDto(hasLike, hasRegistration, isHost);
 	}
 
 	public List<ProgramOutlineResponseDto> findSimilarPrograms(Program program, Member member) {

--- a/src/main/java/com/efub/dhs/domain/registration/repository/RegistrationRepository.java
+++ b/src/main/java/com/efub/dhs/domain/registration/repository/RegistrationRepository.java
@@ -1,0 +1,12 @@
+package com.efub.dhs.domain.registration.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.registration.entity.Registration;
+
+public interface RegistrationRepository extends JpaRepository<Registration, Long> {
+
+	Boolean existsByMemberAndProgram(Member member, Program program);
+}

--- a/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
+++ b/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
@@ -1,0 +1,23 @@
+package com.efub.dhs.domain.registration.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.registration.repository.RegistrationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RegistrationService {
+
+	private final RegistrationRepository registrationRepository;
+
+	@Transactional(readOnly = true)
+	public Boolean existsByMemberAndProgram(Member member, Program program) {
+		return registrationRepository.existsByMemberAndProgram(member, program);
+	}
+}


### PR DESCRIPTION
## 📣 Description

행사 상세 조회 기능 구현하였습니다. 

행사 관련한 Dto가 많은데, 저희가 브랜치랑 패키지를 분리하지 않고 같이 쓰기 때문에 
제가 만든 것들을 빨리 푸시하는 게 좋겠다고 생각해서..
코드가 완벽하지는 않지만 일단 pr 올렸습니다!

- otherPrograms는 같은 카테고리에 속하며, 행사 날짜의 month가 같은 3개 행사로 만들려고 했는데,
행사 날짜 조건 때문에 오류가 나서 일단 카테고리 조건만 넣어두었습니다. 
- 사용자가 로그인 없이 행사 상세 조회 페이지에 접속했을 때도 에러가 나지 않도록 수정해야 합니다.


resolve #14 

## 📸 Screenshot

<img width="1400" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/7b53434a-89f5-4ece-bea7-5acd3b592090">

- response (1)
<img width="1399" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/8f999b85-d298-4c8b-bf0b-0f1f0bd0bc72">

- response (2)
<img width="1400" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/0c5623a4-071d-42c9-b885-1e59f29f37a3">



## 📝 ETC
