### PR TITLE
[FEAT] 행사 참가 신청 API

### DIFF
--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -11,10 +11,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.efub.dhs.domain.program.dto.request.ProgramRegistryRequestDto;
+import com.efub.dhs.domain.program.dto.request.ProgramCreationRequestDto;
+import com.efub.dhs.domain.program.dto.request.ProgramRegistrationRequestDto;
+import com.efub.dhs.domain.program.dto.response.ProgramCreationResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramDetailResponseDto;
-import com.efub.dhs.domain.program.dto.response.ProgramRegistryResponseDto;
+import com.efub.dhs.domain.program.dto.response.ProgramRegistrationResponseDto;
 import com.efub.dhs.domain.program.service.ProgramService;
+import com.efub.dhs.domain.registration.entity.Registration;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,7 +36,15 @@ public class ProgramController {
 
 	@PostMapping
 	@ResponseStatus(value = HttpStatus.CREATED)
-	public ProgramRegistryResponseDto registerProgram(@RequestBody @Valid ProgramRegistryRequestDto requestDto) {
-		return new ProgramRegistryResponseDto(programService.registerProgram(requestDto));
+	public ProgramCreationResponseDto createProgram(@RequestBody @Valid ProgramCreationRequestDto requestDto) {
+		return new ProgramCreationResponseDto(programService.createProgram(requestDto));
+	}
+
+	@PostMapping("/{programId}")
+	@ResponseStatus(value = HttpStatus.CREATED)
+	public ProgramRegistrationResponseDto applyProgram(@PathVariable Long programId,
+		@RequestBody @Valid ProgramRegistrationRequestDto requestDto) {
+		Registration savedRegistration = programService.registerProgram(programId, requestDto);
+		return ProgramRegistrationResponseDto.from(savedRegistration);
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +16,9 @@ import com.efub.dhs.domain.program.dto.request.ProgramCreationRequestDto;
 import com.efub.dhs.domain.program.dto.request.ProgramRegistrationRequestDto;
 import com.efub.dhs.domain.program.dto.response.ProgramCreationResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramDetailResponseDto;
+import com.efub.dhs.domain.program.dto.response.ProgramLikedResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramRegistrationResponseDto;
+import com.efub.dhs.domain.program.service.ProgramMemberService;
 import com.efub.dhs.domain.program.service.ProgramService;
 import com.efub.dhs.domain.registration.entity.Registration;
 
@@ -27,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class ProgramController {
 
 	private final ProgramService programService;
+	private final ProgramMemberService programMemberService;
 
 	@GetMapping("/{programId}")
 	@ResponseStatus(value = HttpStatus.OK)
@@ -46,5 +50,10 @@ public class ProgramController {
 		@RequestBody @Valid ProgramRegistrationRequestDto requestDto) {
 		Registration savedRegistration = programService.registerProgram(programId, requestDto);
 		return ProgramRegistrationResponseDto.from(savedRegistration);
+	}
+
+	@GetMapping("/liked")
+	public ProgramLikedResponseDto findProgramLiked(@RequestParam int page) {
+		return programMemberService.findProgramLiked(page);
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/dto/PageInfoDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/PageInfoDto.java
@@ -1,0 +1,34 @@
+package com.efub.dhs.domain.program.dto;
+
+import org.springframework.data.domain.Page;
+
+import com.efub.dhs.domain.program.entity.Program;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PageInfoDto {
+
+	private final int pageNum;
+	private final int pageSize;
+	private final long totalElements;
+	private final int totalPages;
+
+	@Builder
+	private PageInfoDto(int pageNum, int pageSize, long totalElements, int totalPages) {
+		this.pageNum = pageNum;
+		this.pageSize = pageSize;
+		this.totalElements = totalElements;
+		this.totalPages = totalPages;
+	}
+
+	public static PageInfoDto from(Page<Program> page) {
+		return PageInfoDto.builder()
+			.pageNum(page.getNumber())
+			.pageSize(page.getSize())
+			.totalElements(page.getTotalElements())
+			.totalPages(page.getTotalPages())
+			.build();
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/request/ProgramCreationRequestDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/request/ProgramCreationRequestDto.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProgramRegistryRequestDto {
+public class ProgramCreationRequestDto {
 
 	@NotBlank
 	private String title;

--- a/src/main/java/com/efub/dhs/domain/program/dto/request/ProgramRegistrationRequestDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/request/ProgramRegistrationRequestDto.java
@@ -1,0 +1,52 @@
+package com.efub.dhs.domain.program.dto.request;
+
+import java.time.LocalDateTime;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.PastOrPresent;
+
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.registration.entity.Registration;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProgramRegistrationRequestDto {
+
+	private String depositorName;
+	private String depositAmount;
+	@PastOrPresent
+	private LocalDateTime depositDate;
+	
+	@NotBlank
+	private String registrantName;
+	@NotBlank
+	private String registrantPhone;
+
+	private String refundBank;
+	private String refundAccount;
+	private String refundName;
+
+	public Registration toEntity(Member member, Program program) {
+		return Registration.builder()
+			.member(member)
+			.program(program)
+			.registrantName(registrantName)
+			.registrantPhone(registrantPhone)
+			.depositName(depositorName)
+			.depositDate(depositDate)
+			.depositAmount(depositAmount)
+			.refundBank(refundBank)
+			.refundAccount(refundAccount)
+			.refundName(refundName)
+			.build();
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramCreationResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramCreationResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ProgramRegistryResponseDto {
+public class ProgramCreationResponseDto {
 
 	private long programId;
 }

--- a/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramLikedResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramLikedResponseDto.java
@@ -1,0 +1,16 @@
+package com.efub.dhs.domain.program.dto.response;
+
+import java.util.List;
+
+import com.efub.dhs.domain.program.dto.PageInfoDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProgramLikedResponseDto {
+
+	private List<ProgramOutlineResponseDto> programs;
+	private PageInfoDto pageInfo;
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramRegistrationResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramRegistrationResponseDto.java
@@ -1,0 +1,32 @@
+package com.efub.dhs.domain.program.dto.response;
+
+import com.efub.dhs.domain.program.dto.request.ProgramRegistrationRequestDto;
+import com.efub.dhs.domain.registration.entity.Registration;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProgramRegistrationResponseDto {
+
+	private long registrationId;
+	private ProgramRegistrationRequestDto registrationInfo;
+
+	public static ProgramRegistrationResponseDto from(Registration registration) {
+		return new ProgramRegistrationResponseDto(
+			registration.getRegistrationId(),
+			ProgramRegistrationRequestDto.builder()
+				.depositorName(registration.getDepositName())
+				.depositAmount(registration.getDepositAmount())
+				.depositDate(registration.getDepositDate())
+				.registrantName(registration.getRegistrantName())
+				.registrantPhone(registration.getRegistrantPhone())
+				.refundBank(registration.getRefundBank())
+				.refundAccount(registration.getRefundAccount())
+				.refundName(registration.getRefundName())
+				.build()
+		);
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
@@ -2,8 +2,12 @@ package com.efub.dhs.domain.program.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import com.efub.dhs.domain.member.entity.Member;
 import com.efub.dhs.domain.program.entity.Category;
 import com.efub.dhs.domain.program.entity.Program;
 
@@ -11,4 +15,9 @@ public interface ProgramRepository extends JpaRepository<Program, Long> {
 
 	//List<Program> findTop3ByCategoryAndScheduleMonth(Category category, Month month);
 	List<Program> findTop3ByCategory(Category category);
+
+	Page<Program> findAllByHost(Member host, Pageable pageable);
+
+	@Query(value = "select p from Program p join fetch Heart h on h.program=p where h.member=?1")
+	Page<Program> findAllProgramLiked(Member member, Pageable pageable);
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
@@ -1,0 +1,37 @@
+package com.efub.dhs.domain.program.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.program.dto.PageInfoDto;
+import com.efub.dhs.domain.program.dto.response.ProgramLikedResponseDto;
+import com.efub.dhs.domain.program.dto.response.ProgramOutlineResponseDto;
+import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.program.repository.ProgramRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProgramMemberService {
+
+	private static final int PAGE_SIZE = 12;
+
+	private final ProgramRepository programRepository;
+	private final ProgramService programService;
+
+	@Transactional(readOnly = true)
+	public ProgramLikedResponseDto findProgramLiked(int page) {
+		Member currentUser = programService.getCurrentUser();
+		Page<Program> programPage = programRepository.findAllProgramLiked(currentUser, PageRequest.of(page, PAGE_SIZE));
+		PageInfoDto pageInfoDto = PageInfoDto.from(programPage);
+		List<ProgramOutlineResponseDto> programOutlineResponseDtoList =
+			programService.convertToProgramOutlineResponseDtoList(programPage.getContent(), currentUser);
+		return new ProgramLikedResponseDto(programOutlineResponseDtoList, pageInfoDto);
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -45,7 +45,7 @@ public class ProgramService {
 	private final HeartService heartService;
 	private final RegistrationService registrationService;
 
-	private Member getCurrentUser() {
+	public Member getCurrentUser() {
 		String username = SecurityUtils.getCurrentUsername();
 		return memberRepository.findByUsername(username)
 			.orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원을 찾을 수 없습니다."));
@@ -115,11 +115,15 @@ public class ProgramService {
 	public List<ProgramOutlineResponseDto> findSimilarPrograms(Program program, Member member) {
 		List<Program> similarPrograms =
 			programRepository.findTop3ByCategory(program.getCategory());
+		return convertToProgramOutlineResponseDtoList(similarPrograms, member);
+	}
 
-		return similarPrograms.stream().map(similarProgram ->
-			new ProgramOutlineResponseDto(similarProgram,
-				calculateRemainingDays(similarProgram.getDeadline()),
-				findGoalByProgram(similarProgram.getTargetNumber(), similarProgram.getRegistrantNumber()),
+	public List<ProgramOutlineResponseDto> convertToProgramOutlineResponseDtoList(
+		List<Program> programList, Member member) {
+		return programList.stream().map(program ->
+			new ProgramOutlineResponseDto(program,
+				calculateRemainingDays(program.getDeadline()),
+				findGoalByProgram(program.getTargetNumber(), program.getRegistrantNumber()),
 				heartService.existsByMemberAndProgram(member, program))
 		).collect(Collectors.toList());
 	}

--- a/src/main/java/com/efub/dhs/domain/registration/entity/Registration.java
+++ b/src/main/java/com/efub/dhs/domain/registration/entity/Registration.java
@@ -68,19 +68,18 @@ public class Registration {
 	private String refundName;
 
 	@Builder
-	public Registration(Member member, Program program, String registrantName,
-		String registrantPhone, Boolean depositCheck, String depositName,
-		LocalDateTime depositDate, String depositAmount, RefundStatus refundStatus,
+	public Registration(Member member, Program program, String registrantName, String registrantPhone,
+		String depositName, LocalDateTime depositDate, String depositAmount,
 		String refundBank, String refundAccount, String refundName) {
 		this.member = member;
 		this.program = program;
 		this.registrantName = registrantName;
 		this.registrantPhone = registrantPhone;
-		this.depositCheck = depositCheck;
+		this.depositCheck = false;
 		this.depositName = depositName;
 		this.depositDate = depositDate;
 		this.depositAmount = depositAmount;
-		this.refundStatus = refundStatus;
+		this.refundStatus = RefundStatus.NONE;
 		this.refundBank = refundBank;
 		this.refundAccount = refundAccount;
 		this.refundName = refundName;

--- a/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
+++ b/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.efub.dhs.domain.member.entity.Member;
 import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.registration.entity.Registration;
 import com.efub.dhs.domain.registration.repository.RegistrationRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,5 +20,10 @@ public class RegistrationService {
 	@Transactional(readOnly = true)
 	public Boolean existsByMemberAndProgram(Member member, Program program) {
 		return registrationRepository.existsByMemberAndProgram(member, program);
+	}
+
+	@Transactional(readOnly = true)
+	public Registration saveRegistration(Registration registration) {
+		return registrationRepository.save(registration);
 	}
 }


### PR DESCRIPTION
## 📣 Description

행사(프로그램) 등록에 이어서 신청 API를 개발했습니다.
기능이 크지 않아서 그리고 빠른 개발을 위해서 이전 PR(프로그램 등록) 리뷰 받기 전에 바로 이어서 작업 했는데 각각 리뷰하기 편하도록 PR은 분리하려고 이런 브랜치 구조로 했습니다.
요청DTO에서는 신청자 정보만 필수이고, 입금자 정보와 환불 정보는 무료 공연인 경우 없을 수도 있나..? 싶어서 필수는 아닙니다. 입금 시간은 현재 또는 과거인 경우에만 유효합니다.

Issue Number: solved #26

## 📸 Screenshot

<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/5eefa64e-7525-4339-8e68-7bc9fcb072a6">

## 📝 ETC
