### PR TITLE
[FEAT] 행사 좋아요 API

### DIFF
--- a/src/main/java/com/efub/dhs/domain/heart/controller/HeartController.java
+++ b/src/main/java/com/efub/dhs/domain/heart/controller/HeartController.java
@@ -1,0 +1,28 @@
+package com.efub.dhs.domain.heart.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.efub.dhs.domain.heart.dto.HeartRequestDto;
+import com.efub.dhs.domain.heart.dto.HeartResponseDto;
+import com.efub.dhs.domain.heart.service.HeartService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/hearts")
+public class HeartController {
+
+	private final HeartService heartService;
+
+	@PostMapping
+	public ResponseEntity<HeartResponseDto> likeProgram(@RequestBody @Valid HeartRequestDto requestDto) {
+		return heartService.heartProgram(requestDto.getProgramId());
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/heart/dto/HeartRequestDto.java
+++ b/src/main/java/com/efub/dhs/domain/heart/dto/HeartRequestDto.java
@@ -1,0 +1,17 @@
+package com.efub.dhs.domain.heart.dto;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HeartRequestDto {
+
+	@Positive
+	@NotNull
+	private Long programId;
+}

--- a/src/main/java/com/efub/dhs/domain/heart/dto/HeartResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/heart/dto/HeartResponseDto.java
@@ -1,0 +1,13 @@
+package com.efub.dhs.domain.heart.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HeartResponseDto {
+
+	private Long programId;
+	private Long heartId;
+	private Boolean isExist;
+}

--- a/src/main/java/com/efub/dhs/domain/heart/entity/Heart.java
+++ b/src/main/java/com/efub/dhs/domain/heart/entity/Heart.java
@@ -39,6 +39,14 @@ public class Heart {
 	public Heart(Member member, Program program) {
 		this.member = member;
 		this.program = program;
+		this.exist = false;
+	}
+
+	public void activateHeart() {
 		this.exist = true;
+	}
+
+	public void deactivateHeart() {
+		this.exist = false;
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/heart/service/HeartService.java
+++ b/src/main/java/com/efub/dhs/domain/heart/service/HeartService.java
@@ -1,12 +1,19 @@
 package com.efub.dhs.domain.heart.service;
 
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.efub.dhs.domain.heart.dto.HeartResponseDto;
 import com.efub.dhs.domain.heart.entity.Heart;
 import com.efub.dhs.domain.heart.repository.HeartRepository;
 import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.member.repository.MemberRepository;
 import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.program.repository.ProgramRepository;
+import com.efub.dhs.global.utils.SecurityUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,15 +23,61 @@ import lombok.RequiredArgsConstructor;
 public class HeartService {
 
 	private final HeartRepository heartRepository;
+	private final MemberRepository memberRepository;
+	private final ProgramRepository programRepository;
+
+	private Heart getHeart(Member member, Program program) {
+		return heartRepository.findByMemberAndProgram(member, program)
+			.orElseThrow(() -> new IllegalArgumentException("이 회원은 이 행사를 신청하지 않았습니다."));
+	}
 
 	@Transactional(readOnly = true)
 	public Boolean existsByMemberAndProgram(Member member, Program program) {
 		if (heartRepository.existsByMemberAndProgram(member, program)) {
-			Heart heart = heartRepository.findByMemberAndProgram(member, program)
-				.orElseThrow(() -> new IllegalArgumentException("이 회원은 이 행사를 신청하지 않았습니다."));
+			Heart heart = getHeart(member, program);
 			return heart.getExist();
 		} else {
 			return false;
+		}
+	}
+
+	public ResponseEntity<HeartResponseDto> heartProgram(Long programId) {
+		String username = SecurityUtils.getCurrentUsername();
+		Member currentUser = memberRepository.findByUsername(username)
+			.orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원을 찾을 수 없습니다."));
+		Program program = programRepository.findById(programId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 행사를 찾을 수 없습니다."));
+		Heart heart = getOrCreateHeart(currentUser, program);
+		return createOrCancelHeart(programId, heart);
+	}
+
+	private ResponseEntity<HeartResponseDto> createOrCancelHeart(Long programId, Heart heart) {
+		// 좋아요 생성
+		if (Boolean.FALSE.equals(heart.getExist())) {
+			heart.activateHeart();
+			heartRepository.save(heart);
+			String location = "/programs/" + programId;
+			return ResponseEntity
+				.created(URI.create(location))
+				.body(new HeartResponseDto(programId, heart.getHeartId(), heart.getExist()));
+		}
+		// 좋아요 취소
+		heart.deactivateHeart();
+		heartRepository.save(heart);
+		return ResponseEntity
+			.ok()
+			.body(new HeartResponseDto(programId, heart.getHeartId(), heart.getExist()));
+	}
+
+	private Heart getOrCreateHeart(Member member, Program program) {
+		if (heartRepository.existsByMemberAndProgram(member, program)) {
+			return getHeart(member, program);
+		} else {
+			// 좋아요가 아직 없는 경우 새로 생성
+			return Heart.builder()
+				.member(member)
+				.program(program)
+				.build();
 		}
 	}
 }


### PR DESCRIPTION
## 📣 Description

행사 좋아요를 생성 및 취소하는 API를 개발했습니다.
좋아요를 새롭게 생성하거나 취소했던 걸 다시 활성화하면 201을 리턴하고, 
좋아요를 취소하면 200을 리턴합니다.

Issue Number: solved #29 

## 📸 Screenshot

- 좋아요를 생성한 경우
<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/cd0806aa-4995-433b-8a98-41f3af8ef1b1">

- 좋아요를 취소한 경우
<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/36ac33da-8f25-42fc-8c85-7210867cc2fe">


## 📝 ETC
