### PR TITLE
[FEAT] 좋아요한 행사 리스트 조회 API

### DIFF
--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +16,9 @@ import com.efub.dhs.domain.program.dto.request.ProgramCreationRequestDto;
 import com.efub.dhs.domain.program.dto.request.ProgramRegistrationRequestDto;
 import com.efub.dhs.domain.program.dto.response.ProgramCreationResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramDetailResponseDto;
+import com.efub.dhs.domain.program.dto.response.ProgramLikedResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramRegistrationResponseDto;
+import com.efub.dhs.domain.program.service.ProgramMemberService;
 import com.efub.dhs.domain.program.service.ProgramService;
 import com.efub.dhs.domain.registration.entity.Registration;
 
@@ -27,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class ProgramController {
 
 	private final ProgramService programService;
+	private final ProgramMemberService programMemberService;
 
 	@GetMapping("/{programId}")
 	@ResponseStatus(value = HttpStatus.OK)
@@ -46,5 +50,10 @@ public class ProgramController {
 		@RequestBody @Valid ProgramRegistrationRequestDto requestDto) {
 		Registration savedRegistration = programService.registerProgram(programId, requestDto);
 		return ProgramRegistrationResponseDto.from(savedRegistration);
+	}
+
+	@GetMapping("/liked")
+	public ProgramLikedResponseDto findProgramLiked(@RequestParam int page) {
+		return programMemberService.findProgramLiked(page);
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/dto/PageInfoDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/PageInfoDto.java
@@ -1,0 +1,34 @@
+package com.efub.dhs.domain.program.dto;
+
+import org.springframework.data.domain.Page;
+
+import com.efub.dhs.domain.program.entity.Program;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PageInfoDto {
+
+	private final int pageNum;
+	private final int pageSize;
+	private final long totalElements;
+	private final int totalPages;
+
+	@Builder
+	private PageInfoDto(int pageNum, int pageSize, long totalElements, int totalPages) {
+		this.pageNum = pageNum;
+		this.pageSize = pageSize;
+		this.totalElements = totalElements;
+		this.totalPages = totalPages;
+	}
+
+	public static PageInfoDto from(Page<Program> page) {
+		return PageInfoDto.builder()
+			.pageNum(page.getNumber())
+			.pageSize(page.getSize())
+			.totalElements(page.getTotalElements())
+			.totalPages(page.getTotalPages())
+			.build();
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramLikedResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramLikedResponseDto.java
@@ -1,0 +1,16 @@
+package com.efub.dhs.domain.program.dto.response;
+
+import java.util.List;
+
+import com.efub.dhs.domain.program.dto.PageInfoDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProgramLikedResponseDto {
+
+	private List<ProgramOutlineResponseDto> programs;
+	private PageInfoDto pageInfo;
+}

--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
@@ -2,8 +2,12 @@ package com.efub.dhs.domain.program.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import com.efub.dhs.domain.member.entity.Member;
 import com.efub.dhs.domain.program.entity.Category;
 import com.efub.dhs.domain.program.entity.Program;
 
@@ -11,4 +15,9 @@ public interface ProgramRepository extends JpaRepository<Program, Long> {
 
 	//List<Program> findTop3ByCategoryAndScheduleMonth(Category category, Month month);
 	List<Program> findTop3ByCategory(Category category);
+
+	Page<Program> findAllByHost(Member host, Pageable pageable);
+
+	@Query(value = "select p from Program p join fetch Heart h on h.program=p where h.member=?1")
+	Page<Program> findAllProgramLiked(Member member, Pageable pageable);
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
@@ -1,0 +1,37 @@
+package com.efub.dhs.domain.program.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.program.dto.PageInfoDto;
+import com.efub.dhs.domain.program.dto.response.ProgramLikedResponseDto;
+import com.efub.dhs.domain.program.dto.response.ProgramOutlineResponseDto;
+import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.program.repository.ProgramRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProgramMemberService {
+
+	private static final int PAGE_SIZE = 12;
+
+	private final ProgramRepository programRepository;
+	private final ProgramService programService;
+
+	@Transactional(readOnly = true)
+	public ProgramLikedResponseDto findProgramLiked(int page) {
+		Member currentUser = programService.getCurrentUser();
+		Page<Program> programPage = programRepository.findAllProgramLiked(currentUser, PageRequest.of(page, PAGE_SIZE));
+		PageInfoDto pageInfoDto = PageInfoDto.from(programPage);
+		List<ProgramOutlineResponseDto> programOutlineResponseDtoList =
+			programService.convertToProgramOutlineResponseDtoList(programPage.getContent(), currentUser);
+		return new ProgramLikedResponseDto(programOutlineResponseDtoList, pageInfoDto);
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -45,7 +45,7 @@ public class ProgramService {
 	private final HeartService heartService;
 	private final RegistrationService registrationService;
 
-	private Member getCurrentUser() {
+	public Member getCurrentUser() {
 		String username = SecurityUtils.getCurrentUsername();
 		return memberRepository.findByUsername(username)
 			.orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원을 찾을 수 없습니다."));
@@ -115,11 +115,15 @@ public class ProgramService {
 	public List<ProgramOutlineResponseDto> findSimilarPrograms(Program program, Member member) {
 		List<Program> similarPrograms =
 			programRepository.findTop3ByCategory(program.getCategory());
+		return convertToProgramOutlineResponseDtoList(similarPrograms, member);
+	}
 
-		return similarPrograms.stream().map(similarProgram ->
-			new ProgramOutlineResponseDto(similarProgram,
-				calculateRemainingDays(similarProgram.getDeadline()),
-				findGoalByProgram(similarProgram.getTargetNumber(), similarProgram.getRegistrantNumber()),
+	public List<ProgramOutlineResponseDto> convertToProgramOutlineResponseDtoList(
+		List<Program> programList, Member member) {
+		return programList.stream().map(program ->
+			new ProgramOutlineResponseDto(program,
+				calculateRemainingDays(program.getDeadline()),
+				findGoalByProgram(program.getTargetNumber(), program.getRegistrantNumber()),
 				heartService.existsByMemberAndProgram(member, program))
 		).collect(Collectors.toList());
 	}


### PR DESCRIPTION
## 📣 Description

유저가 좋아요한 행사 리스트를 조회하는 API입니다. 
행사 신청 API PR과 같이 빠른 개발을 위해서 리뷰 받기 전에 바로 이어서 작업 했는데 각각 리뷰하기 편하도록 PR은 분리하려고 이런 브랜치 구조로 했습니다.
페이지 번호만 요청 파라미터로 넘겨 받고, 페이지 사이즈는 12로 고정되어 있습니다.
그리고 유저가 좋아요한/신청한/등록한 페이지 조회 기능이 다 비슷해서 그냥 제가 해도 될 것 같은데 어떤가용..?

Issue Number: solved #31 

## 📸 Screenshot

아래는 좋아요한 행사가 총 14개이고, 페이지 사이즈가 12인 경우의 예시입니다.

- 0번 페이지
<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/1a364d33-33f8-45a3-84a5-403af798627f">

- 1번 페이지
<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/785a36c5-e114-4978-b860-e696ee4ec1a4">


## 📝 ETC
