### PR TITLE
[FEAT] CORS 설정 추가

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:
-      test: [ 'CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -u root --password=$${MYSQL_ROOT_PASSWORD}' ]
+      test: [ 'CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -u root' ]
       interval: 10s
       timeout: 2s
       retries: 100

--- a/src/main/java/com/efub/dhs/global/config/CorsConfig.java
+++ b/src/main/java/com/efub/dhs/global/config/CorsConfig.java
@@ -1,0 +1,20 @@
+package com.efub.dhs.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("http://api.daehaengsa.kro.kr",
+				"https://api.daehaengsa.kro.kr",
+				"http://localhost:3000",
+				"https://daehaengsa.kro.kr")
+			.allowedMethods("GET", "POST")
+			.maxAge(3000);
+	}
+}


### PR DESCRIPTION
## 📣 Description

다음 Origin 대해서 CORS 허용 설정 추가했습니다.
프론트엔드 로컬 개발용 : http://localhost:3000
대행사 도메인 : https://daehaengsa.kro.kr
Origin 허용한게 전부여서 바로 머지할게요..!

Issue Number: solved #33 

## 📸 Screenshot

배포해서 잘 돌아가는 거 확인해봤습니다~
<img width="527" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/65032044-9c4d-4185-b0f6-22e78102257f">

CORS 설정 추가하기 전에는 이렇게 Invalid CORS Request라고 뜹니다
<img width="354" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/5bdfcf40-56c4-43a1-9992-8cb30c5c1751">


## 📝 ETC
