### PR TITLE
[FEAT] 등록한 행사 리스트 조회 API

### DIFF
--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.efub.dhs.domain.program.dto.request.ProgramCreationRequestDto;
 import com.efub.dhs.domain.program.dto.request.ProgramRegistrationRequestDto;
+import com.efub.dhs.domain.program.dto.response.ProgramCreatedResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramCreationResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramDetailResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramLikedResponseDto;
@@ -50,6 +51,11 @@ public class ProgramController {
 		@RequestBody @Valid ProgramRegistrationRequestDto requestDto) {
 		Registration savedRegistration = programService.registerProgram(programId, requestDto);
 		return ProgramRegistrationResponseDto.from(savedRegistration);
+	}
+
+	@GetMapping("/created")
+	public ProgramCreatedResponseDto findProgramCreated(@RequestParam int page) {
+		return programMemberService.findProgramCreated(page);
 	}
 
 	@GetMapping("/liked")

--- a/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramCreatedResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramCreatedResponseDto.java
@@ -1,0 +1,16 @@
+package com.efub.dhs.domain.program.dto.response;
+
+import java.util.List;
+
+import com.efub.dhs.domain.program.dto.PageInfoDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProgramCreatedResponseDto {
+
+	private List<ProgramOutlineResponseDto> programs;
+	private PageInfoDto pageInfo;
+}

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.efub.dhs.domain.member.entity.Member;
 import com.efub.dhs.domain.program.dto.PageInfoDto;
+import com.efub.dhs.domain.program.dto.response.ProgramCreatedResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramLikedResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramOutlineResponseDto;
 import com.efub.dhs.domain.program.entity.Program;
@@ -24,6 +25,16 @@ public class ProgramMemberService {
 
 	private final ProgramRepository programRepository;
 	private final ProgramService programService;
+
+	@Transactional(readOnly = true)
+	public ProgramCreatedResponseDto findProgramCreated(int page) {
+		Member currentUser = programService.getCurrentUser();
+		Page<Program> programPage = programRepository.findAllByHost(currentUser, PageRequest.of(page, PAGE_SIZE));
+		PageInfoDto pageInfoDto = PageInfoDto.from(programPage);
+		List<ProgramOutlineResponseDto> programOutlineResponseDtoList =
+			programService.convertToProgramOutlineResponseDtoList(programPage.getContent(), currentUser);
+		return new ProgramCreatedResponseDto(programOutlineResponseDtoList, pageInfoDto);
+	}
 
 	@Transactional(readOnly = true)
 	public ProgramLikedResponseDto findProgramLiked(int page) {


### PR DESCRIPTION
## 📣 Description

등록한 행사 리스트를 조회하는 API를 개발했습니다.
응답 DTO 구조는 좋아요한 행사 리스트 API와 동일합니다.

Issue Number: solved #17 

## 📸 Screenshot

<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/2c92dc21-3fe0-4584-91c2-a88d372ae8de">

## 📝 ETC
