### PR TITLE
[FEAT] 인기 행사 리스트 조회 API

### DIFF
--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -1,5 +1,7 @@
 package com.efub.dhs.domain.program.controller;
 
+import java.util.List;
+
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -18,6 +20,7 @@ import com.efub.dhs.domain.program.dto.request.ProgramRegistrationRequestDto;
 import com.efub.dhs.domain.program.dto.response.ProgramCreationResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramDetailResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramListResponseDto;
+import com.efub.dhs.domain.program.dto.response.ProgramOutlineResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramRegistrationResponseDto;
 import com.efub.dhs.domain.program.service.ProgramMemberService;
 import com.efub.dhs.domain.program.service.ProgramService;
@@ -61,5 +64,10 @@ public class ProgramController {
 	@GetMapping
 	public ProgramListResponseDto findProgramList(@RequestParam int page, ProgramListRequestDto requestDto) {
 		return programService.findProgramList(page, requestDto);
+	}
+
+	@GetMapping("/popular")
+	public List<ProgramOutlineResponseDto> findProgramPopular() {
+		return programService.findProgramPopular();
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
@@ -20,4 +20,6 @@ public interface ProgramRepository extends JpaRepository<Program, Long>, Program
 
 	@Query(value = "select p from Program p join fetch Heart h on h.program=p where h.member=?1")
 	Page<Program> findAllProgramLiked(Member member, Pageable pageable);
+	
+	List<Program> findTop5ByOrderByLikeNumberDesc();
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -160,4 +160,14 @@ public class ProgramService {
 			convertToProgramOutlineResponseDtoList(programPage.getContent(), currentUser);
 		return new ProgramListResponseDto(programOutlineResponseDtoList, pageInfoDto);
 	}
+
+	public List<ProgramOutlineResponseDto> findProgramPopular() {
+		List<Program> programList = programRepository.findTop5ByOrderByLikeNumberDesc();
+		return programList.stream().map(program ->
+			new ProgramOutlineResponseDto(program,
+				calculateRemainingDays(program.getDeadline()),
+				findGoalByProgram(program.getTargetNumber(), program.getRegistrantNumber()),
+				false)
+		).collect(Collectors.toList());
+	}
 }


### PR DESCRIPTION
## 📣 Description

인기 행사 리스트 5개를 조회합니다.
좋아요 수를 기준으로 정렬했습니다.

Issue Number: solved #37 

## 📸 Screenshot

- like_number 순으로 정렬 시 program_id 순서: 5, 2, 4, 3, 1, 6
<img width="1007" alt="스크린샷 2023-11-22 오후 9 26 45" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/71311a71-bada-45b1-9d8a-854c4943d3c2">

- 테스트 시 program_id 5, 2, 4, 3, 1 순서로 나오는 것을 확인할 수 있습니다
<img width="1006" alt="스크린샷 2023-11-22 오후 9 44 24" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/d287e1fe-1b58-4b87-8dc2-03766f580860">
<img width="1006" alt="스크린샷 2023-11-22 오후 9 44 31" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/981a245b-9b3a-4e89-8813-2cc87b7a18e6">
<img width="1006" alt="스크린샷 2023-11-22 오후 9 44 39" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/86386da4-d1dc-4ec1-800c-9b322ad03d07">




## 📝 ETC
