### PR TITLE
[FEAT] 신청자 리스트 조회 API

### DIFF
--- a/src/main/java/com/efub/dhs/domain/member/service/MemberService.java
+++ b/src/main/java/com/efub/dhs/domain/member/service/MemberService.java
@@ -1,0 +1,23 @@
+package com.efub.dhs.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.member.repository.MemberRepository;
+import com.efub.dhs.global.utils.SecurityUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+	private final MemberRepository memberRepository;
+
+	public Member getCurrentUser() {
+		String username = SecurityUtils.getCurrentUsername();
+		return memberRepository.findByUsername(username)
+			.orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원을 찾을 수 없습니다."));
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -20,12 +20,15 @@ import com.efub.dhs.domain.program.dto.request.ProgramRegistrationRequestDto;
 import com.efub.dhs.domain.program.dto.response.ProgramCreationResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramDetailResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramListResponseDto;
-import com.efub.dhs.domain.program.dto.response.ProgramRegisteredResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramOutlineResponseDto;
+import com.efub.dhs.domain.program.dto.response.ProgramRegisteredResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramRegistrationResponseDto;
+import com.efub.dhs.domain.program.entity.Program;
 import com.efub.dhs.domain.program.service.ProgramMemberService;
 import com.efub.dhs.domain.program.service.ProgramService;
+import com.efub.dhs.domain.registration.dto.RegistrationResponseDto;
 import com.efub.dhs.domain.registration.entity.Registration;
+import com.efub.dhs.domain.registration.service.RegistrationService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,6 +39,7 @@ public class ProgramController {
 
 	private final ProgramService programService;
 	private final ProgramMemberService programMemberService;
+	private final RegistrationService registrationService;
 
 	@GetMapping("/{programId}")
 	@ResponseStatus(value = HttpStatus.OK)
@@ -70,8 +74,8 @@ public class ProgramController {
 	@GetMapping("/registered")
 	public ProgramRegisteredResponseDto findProgramRegistered(@RequestParam int page) {
 		return programMemberService.findProgramRegistered(page);
-  }
-  
+	}
+
 	@GetMapping
 	public ProgramListResponseDto findProgramList(@RequestParam int page, ProgramListRequestDto requestDto) {
 		return programService.findProgramList(page, requestDto);
@@ -80,5 +84,11 @@ public class ProgramController {
 	@GetMapping("/popular")
 	public List<ProgramOutlineResponseDto> findProgramPopular() {
 		return programService.findProgramPopular();
+	}
+
+	@GetMapping("/{programId}/registrations")
+	public List<RegistrationResponseDto> findRegistratorList(@PathVariable Long programId) {
+		Program program = programService.getProgram(programId);
+		return registrationService.findRegistratorList(program);
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.efub.dhs.domain.heart.service.HeartService;
 import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.member.service.MemberService;
 import com.efub.dhs.domain.program.dto.PageInfoDto;
 import com.efub.dhs.domain.program.dto.response.ProgramListResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramOutlineResponseDto;
@@ -33,10 +34,11 @@ public class ProgramMemberService {
 	private final RegistrationRepository registrationRepository;
 	private final ProgramService programService;
 	private final HeartService heartService;
+	private final MemberService memberService;
 
 	@Transactional(readOnly = true)
 	public ProgramListResponseDto findProgramCreated(int page) {
-		Member currentUser = programService.getCurrentUser();
+		Member currentUser = memberService.getCurrentUser();
 		Page<Program> programPage = programRepository.findAllByHost(currentUser, PageRequest.of(page, PAGE_SIZE));
 		PageInfoDto pageInfoDto = PageInfoDto.createProgramPageInfoDto(programPage);
 		List<ProgramOutlineResponseDto> programOutlineResponseDtoList =
@@ -46,7 +48,7 @@ public class ProgramMemberService {
 
 	@Transactional(readOnly = true)
 	public ProgramListResponseDto findProgramLiked(int page) {
-		Member currentUser = programService.getCurrentUser();
+		Member currentUser = memberService.getCurrentUser();
 		Page<Program> programPage = programRepository.findAllProgramLiked(currentUser, PageRequest.of(page, PAGE_SIZE));
 		PageInfoDto pageInfoDto = PageInfoDto.createProgramPageInfoDto(programPage);
 		List<ProgramOutlineResponseDto> programOutlineResponseDtoList =
@@ -56,7 +58,7 @@ public class ProgramMemberService {
 
 	@Transactional(readOnly = true)
 	public ProgramRegisteredResponseDto findProgramRegistered(int page) {
-		Member currentUser = programService.getCurrentUser();
+		Member currentUser = memberService.getCurrentUser();
 		Page<Registration> registrationPage = registrationRepository.findRegisteredPrograms(
 			currentUser, PageRequest.of(page, PAGE_SIZE));
 		PageInfoDto pageInfoDto = PageInfoDto.createRegistrationPageInfoDto(registrationPage);

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.efub.dhs.domain.heart.service.HeartService;
 import com.efub.dhs.domain.member.entity.Member;
-import com.efub.dhs.domain.member.repository.MemberRepository;
+import com.efub.dhs.domain.member.service.MemberService;
 import com.efub.dhs.domain.program.dto.GoalDto;
 import com.efub.dhs.domain.program.dto.HostDto;
 import com.efub.dhs.domain.program.dto.ImageDto;
@@ -34,7 +34,6 @@ import com.efub.dhs.domain.program.repository.ProgramImageRepository;
 import com.efub.dhs.domain.program.repository.ProgramRepository;
 import com.efub.dhs.domain.registration.entity.Registration;
 import com.efub.dhs.domain.registration.service.RegistrationService;
-import com.efub.dhs.global.utils.SecurityUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -48,17 +47,11 @@ public class ProgramService {
 	private final ProgramRepository programRepository;
 	private final ProgramImageRepository programImageRepository;
 	private final NoticeRepository noticeRepository;
-	private final MemberRepository memberRepository;
+	private final MemberService memberService;
 	private final HeartService heartService;
 	private final RegistrationService registrationService;
 
-	public Member getCurrentUser() {
-		String username = SecurityUtils.getCurrentUsername();
-		return memberRepository.findByUsername(username)
-			.orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원을 찾을 수 없습니다."));
-	}
-
-	private Program getProgram(Long programId) {
+	public Program getProgram(Long programId) {
 		return programRepository.findById(programId)
 			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 행사를 찾을 수 없습니다."));
 	}
@@ -67,7 +60,7 @@ public class ProgramService {
 	public ProgramDetailResponseDto findProgramById(Long programId) {
 		Program program = getProgram(programId);
 
-		Member currentUser = getCurrentUser();
+		Member currentUser = memberService.getCurrentUser();
 
 		Integer remainingDays = calculateRemainingDays(program.getDeadline());
 
@@ -136,7 +129,7 @@ public class ProgramService {
 	}
 
 	public Long createProgram(ProgramCreationRequestDto requestDto) {
-		Member currentUser = getCurrentUser();
+		Member currentUser = memberService.getCurrentUser();
 		Program program = requestDto.toEntity(currentUser);
 		Long programId = programRepository.save(program).getProgramId();
 		List<ProgramImage> images = program.getImages();
@@ -145,17 +138,17 @@ public class ProgramService {
 	}
 
 	public Registration registerProgram(Long programId, ProgramRegistrationRequestDto requestDto) {
-		Member currentUser = getCurrentUser();
+		Member currentUser = memberService.getCurrentUser();
 		Program program = getProgram(programId);
 		Registration registration = requestDto.toEntity(currentUser, program);
 		return registrationService.saveRegistration(registration);
 	}
 
 	public ProgramListResponseDto findProgramList(int page, ProgramListRequestDto requestDto) {
-		Member currentUser = getCurrentUser();
+		Member currentUser = memberService.getCurrentUser();
 		Page<Program> programPage = programRepository.findProgramListByFilter(requestDto,
 			PageRequest.of(page, PAGE_SIZE));
-		PageInfoDto pageInfoDto = PageInfoDto.from(programPage);
+		PageInfoDto pageInfoDto = PageInfoDto.createProgramPageInfoDto(programPage);
 		List<ProgramOutlineResponseDto> programOutlineResponseDtoList =
 			convertToProgramOutlineResponseDtoList(programPage.getContent(), currentUser);
 		return new ProgramListResponseDto(programOutlineResponseDtoList, pageInfoDto);

--- a/src/main/java/com/efub/dhs/domain/registration/dto/PaymentDto.java
+++ b/src/main/java/com/efub/dhs/domain/registration/dto/PaymentDto.java
@@ -1,0 +1,24 @@
+package com.efub.dhs.domain.registration.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentDto {
+
+	private Boolean check;
+	private String name;
+	private LocalDateTime date;
+	private String price;
+
+	public PaymentDto(Boolean check, String name, LocalDateTime date, String price) {
+		this.check = check;
+		this.name = name;
+		this.date = date;
+		this.price = price;
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/registration/dto/RefundDto.java
+++ b/src/main/java/com/efub/dhs/domain/registration/dto/RefundDto.java
@@ -1,0 +1,24 @@
+package com.efub.dhs.domain.registration.dto;
+
+import com.efub.dhs.domain.registration.entity.RefundStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefundDto {
+
+	private String status;
+	private String bank;
+	private String account;
+	private String name;
+
+	public RefundDto(RefundStatus refundStatus, String bank, String account, String name) {
+		this.status = RefundStatus.to(refundStatus);
+		this.bank = bank;
+		this.account = account;
+		this.name = name;
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/registration/dto/RegistrationResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/registration/dto/RegistrationResponseDto.java
@@ -1,0 +1,28 @@
+package com.efub.dhs.domain.registration.dto;
+
+import com.efub.dhs.domain.registration.entity.Registration;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class RegistrationResponseDto {
+
+	private String name;
+	private String phone;
+	private PaymentDto payment;
+	private RefundDto refund;
+
+	public static RegistrationResponseDto from(Registration registration) {
+		return new RegistrationResponseDto(
+			registration.getRegistrantName(),
+			registration.getRegistrantPhone(),
+			new PaymentDto(registration.getDepositCheck(), registration.getDepositName(),
+				registration.getDepositDate(), registration.getDepositAmount()),
+			new RefundDto(registration.getRefundStatus(), registration.getRefundBank(),
+				registration.getRefundAccount(), registration.getRefundName())
+		);
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/registration/entity/RefundStatus.java
+++ b/src/main/java/com/efub/dhs/domain/registration/entity/RefundStatus.java
@@ -1,5 +1,7 @@
 package com.efub.dhs.domain.registration.entity;
 
+import java.util.Arrays;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -9,4 +11,15 @@ public enum RefundStatus {
 	COMPLETED("환불완료");
 
 	private final String name;
+
+	public static RefundStatus from(String name) {
+		return Arrays.stream(RefundStatus.values())
+			.filter(refundStatus -> refundStatus.name.equals(name))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("Invalid RefundStatus name: " + name));
+	}
+
+	public static String to(RefundStatus refundStatus) {
+		return refundStatus.name;
+	}
 }

--- a/src/main/java/com/efub/dhs/domain/registration/repository/RegistrationRepository.java
+++ b/src/main/java/com/efub/dhs/domain/registration/repository/RegistrationRepository.java
@@ -1,5 +1,7 @@
 package com.efub.dhs.domain.registration.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +17,6 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
 
 	@Query(value = "select r from Registration r join fetch Program p on r.program=p where r.member=?1")
 	Page<Registration> findRegisteredPrograms(Member registrant, Pageable pageable);
+
+	List<Registration> findAllByProgram(Program program);
 }

--- a/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
+++ b/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
@@ -1,10 +1,15 @@
 package com.efub.dhs.domain.registration.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.member.service.MemberService;
 import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.registration.dto.RegistrationResponseDto;
 import com.efub.dhs.domain.registration.entity.Registration;
 import com.efub.dhs.domain.registration.repository.RegistrationRepository;
 
@@ -16,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class RegistrationService {
 
 	private final RegistrationRepository registrationRepository;
+	private final MemberService memberService;
 
 	@Transactional(readOnly = true)
 	public Boolean existsByMemberAndProgram(Member member, Program program) {
@@ -25,5 +31,16 @@ public class RegistrationService {
 	@Transactional(readOnly = true)
 	public Registration saveRegistration(Registration registration) {
 		return registrationRepository.save(registration);
+	}
+
+	@Transactional(readOnly = true)
+	public List<RegistrationResponseDto> findRegistratorList(Program program) {
+		Member member = memberService.getCurrentUser();
+		if (member.equals(program.getHost())) {
+			List<Registration> registrationList = registrationRepository.findAllByProgram(program);
+			return registrationList.stream().map(RegistrationResponseDto::from).collect(Collectors.toList());
+		} else {
+			throw new SecurityException("접근 권한이 없습니다.");
+		}
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
+++ b/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
@@ -3,8 +3,10 @@ package com.efub.dhs.domain.registration.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.efub.dhs.domain.member.entity.Member;
 import com.efub.dhs.domain.member.service.MemberService;
@@ -40,7 +42,7 @@ public class RegistrationService {
 			List<Registration> registrationList = registrationRepository.findAllByProgram(program);
 			return registrationList.stream().map(RegistrationResponseDto::from).collect(Collectors.toList());
 		} else {
-			throw new SecurityException("접근 권한이 없습니다.");
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN);
 		}
 	}
 }


### PR DESCRIPTION
## 📣 Description

특정 행사의 신청자 리스트를 조회합니다.
현재 사용자와 행사 등록자를 비교해서 같을 때만 접근 가능하도록 설정하였습니다.

Issue Number: solved #18 

## 📸 Screenshot
- 현재 사용자 == 행사 등록자
<img width="525" alt="스크린샷 2023-11-23 오후 11 30 49" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/9fc4b392-5ba3-4fd2-9c00-708599543009">

- 현재 사용자 != 행사 등록자
<img width="475" alt="스크린샷 2023-11-23 오후 11 33 47" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/d81c3c3b-b15f-4daa-9d16-c872644a75d7">


## 📝 ETC