### PR TITLE
[FEAT] 공지사항 등록 API

### DIFF
--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -14,9 +14,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.efub.dhs.domain.program.dto.request.NoticeCreationRequestDto;
 import com.efub.dhs.domain.program.dto.request.ProgramCreationRequestDto;
 import com.efub.dhs.domain.program.dto.request.ProgramListRequestDto;
 import com.efub.dhs.domain.program.dto.request.ProgramRegistrationRequestDto;
+import com.efub.dhs.domain.program.dto.response.NoticeCreationResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramCreationResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramDetailResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramListResponseDto;
@@ -24,6 +26,7 @@ import com.efub.dhs.domain.program.dto.response.ProgramOutlineResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramRegisteredResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramRegistrationResponseDto;
 import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.program.service.NoticeService;
 import com.efub.dhs.domain.program.service.ProgramMemberService;
 import com.efub.dhs.domain.program.service.ProgramService;
 import com.efub.dhs.domain.registration.dto.RegistrationResponseDto;
@@ -40,6 +43,7 @@ public class ProgramController {
 	private final ProgramService programService;
 	private final ProgramMemberService programMemberService;
 	private final RegistrationService registrationService;
+	private final NoticeService noticeService;
 
 	@GetMapping("/{programId}")
 	@ResponseStatus(value = HttpStatus.OK)
@@ -90,5 +94,13 @@ public class ProgramController {
 	public List<RegistrationResponseDto> findRegistratorList(@PathVariable Long programId) {
 		Program program = programService.getProgram(programId);
 		return registrationService.findRegistratorList(program);
+	}
+
+	@PostMapping("/{programId}/notice")
+	@ResponseStatus(HttpStatus.CREATED)
+	public NoticeCreationResponseDto createNotice(@PathVariable Long programId,
+		@RequestBody NoticeCreationRequestDto requestDto) {
+		Program program = programService.getProgram(programId);
+		return noticeService.createNotice(program, requestDto);
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/dto/request/NoticeCreationRequestDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/request/NoticeCreationRequestDto.java
@@ -1,0 +1,28 @@
+package com.efub.dhs.domain.program.dto.request;
+
+import javax.validation.constraints.NotBlank;
+
+import com.efub.dhs.domain.program.entity.Notice;
+import com.efub.dhs.domain.program.entity.Program;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeCreationRequestDto {
+
+	@NotBlank
+	private String title;
+	@NotBlank
+	private String content;
+
+	public Notice toEntity(Program program) {
+		return Notice.builder()
+			.program(program)
+			.title(title)
+			.content(content)
+			.build();
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/dto/response/NoticeCreationResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/response/NoticeCreationResponseDto.java
@@ -1,0 +1,11 @@
+package com.efub.dhs.domain.program.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NoticeCreationResponseDto {
+
+	private Long noticeId;
+}

--- a/src/main/java/com/efub/dhs/domain/program/service/NoticeService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/NoticeService.java
@@ -1,0 +1,35 @@
+package com.efub.dhs.domain.program.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.efub.dhs.domain.member.entity.Member;
+import com.efub.dhs.domain.member.service.MemberService;
+import com.efub.dhs.domain.program.dto.request.NoticeCreationRequestDto;
+import com.efub.dhs.domain.program.dto.response.NoticeCreationResponseDto;
+import com.efub.dhs.domain.program.entity.Notice;
+import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.program.repository.NoticeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NoticeService {
+
+	private final NoticeRepository noticeRepository;
+	private final MemberService memberService;
+
+	public NoticeCreationResponseDto createNotice(Program program, NoticeCreationRequestDto requestDto) {
+		Member member = memberService.getCurrentUser();
+		if (member.equals(program.getHost())) {
+			Notice notice = noticeRepository.save(requestDto.toEntity(program));
+			return new NoticeCreationResponseDto(notice.getNoticeId());
+		} else {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+		}
+	}
+}


### PR DESCRIPTION
## 📣 Description

특정 행사에 공지사항을 등록합니다.
신청자 리스트 조회와 마찬가지로, 현재 사용자와 행사 등록자를 비교해서 같을 때만 접근 가능하도록 설정하였습니다.

Issue Number: solved #16 

## 📸 Screenshot
- 현재 사용자 == 행사 등록자
<img width="699" alt="스크린샷 2023-11-24 오전 12 24 31" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/c006c4dc-57cf-47b2-8027-65ecc1ffbdbe">

- 현재 사용자 != 행사 등록자
<img width="488" alt="스크린샷 2023-11-24 오전 12 22 54" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/0a4a3d85-cdd6-4acc-bf46-f40c3b08c8b1">

- 공지사항 등록 후 행사 개별 조회
<img width="674" alt="스크린샷 2023-11-24 오전 12 29 24" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/0498fe98-e6d1-41bc-a4ba-ef129b2f3d8d">


## 📝 ETC