### PR TITLE
[FEAT] 행사 마감 API

### DIFF
--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -59,6 +60,12 @@ public class ProgramController {
 		@RequestBody @Valid ProgramRegistrationRequestDto requestDto) {
 		Registration savedRegistration = programService.registerProgram(programId, requestDto);
 		return ProgramRegistrationResponseDto.from(savedRegistration);
+	}
+
+	@PatchMapping("/{programId}/closed")
+	@ResponseStatus(value = HttpStatus.OK)
+	public ProgramDetailResponseDto closeProgram(@PathVariable Long programId) {
+		return programService.closeProgram(programId);
 	}
 
 	@GetMapping("/created")

--- a/src/main/java/com/efub/dhs/domain/program/entity/Program.java
+++ b/src/main/java/com/efub/dhs/domain/program/entity/Program.java
@@ -121,4 +121,8 @@ public class Program extends BaseTimeEntity {
 			.collect(Collectors.toList());
 		this.notices = List.of();
 	}
+
+	public void closeProgram() {
+		this.isOpen = false;
+	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -7,8 +7,10 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.efub.dhs.domain.heart.service.HeartService;
 import com.efub.dhs.domain.member.entity.Member;
@@ -135,6 +137,17 @@ public class ProgramService {
 		List<ProgramImage> images = program.getImages();
 		programImageRepository.saveAll(images);
 		return programId;
+	}
+
+	public ProgramDetailResponseDto closeProgram(Long programId) {
+		Member currentUser = memberService.getCurrentUser();
+		Program program = getProgram(programId);
+		if (currentUser.equals(program.getHost())) {
+			program.closeProgram();
+			return findProgramById(program.getProgramId());
+		} else {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+		}
 	}
 
 	public Registration registerProgram(Long programId, ProgramRegistrationRequestDto requestDto) {


### PR DESCRIPTION
## 📣 Description

행사의 `isOpen` 필드를 false로 변경하여 행사를 마감합니다.
신청자 리스트 조회 및 공지사항 등록과 마찬가지로, 현재 사용자와 행사 등록자가 같을 때만 접근 가능하도록 설정하였습니다.

Issue Number: solved #15 

## 📸 Screenshot
- 현재 사용자 == 행사 등록자
<img width="686" alt="스크린샷 2023-11-24 오전 12 56 03" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/2c5d10c4-fb8a-48ef-9b95-362fa5f7408e">

- 현재 사용자 != 행사 등록자
<img width="686" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/eb9133ea-d1b3-4f6d-9594-64063fe65871">


## 📝 ETC