### PR TITLE
[FEAT] 행사 참가 신청

### DIFF
--- a/src/main/java/com/efub/dhs/domain/member/service/AuthService.java
+++ b/src/main/java/com/efub/dhs/domain/member/service/AuthService.java
@@ -1,10 +1,12 @@
 package com.efub.dhs.domain.member.service;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.efub.dhs.domain.member.entity.Member;
 import com.efub.dhs.domain.member.repository.MemberRepository;
@@ -28,7 +30,7 @@ public class AuthService {
 	public Member signUp(String username, String password) {
 		boolean exists = memberRepository.existsByUsername(username);
 		if (exists) {
-			throw new IllegalArgumentException("동일한 아이디의 유저가 존재합니다.");
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "동일한 아이디의 유저가 존재합니다.");
 		}
 		String encodedPassword = passwordEncoder.encode(password);
 		Member member = Member.builder().username(username).password(encodedPassword).build();

--- a/src/main/java/com/efub/dhs/domain/member/service/MemberService.java
+++ b/src/main/java/com/efub/dhs/domain/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package com.efub.dhs.domain.member.service;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.efub.dhs.domain.member.entity.Member;
 import com.efub.dhs.domain.member.repository.MemberRepository;
@@ -18,6 +20,6 @@ public class MemberService {
 	public Member getCurrentUser() {
 		String username = SecurityUtils.getCurrentUsername();
 		return memberRepository.findByUsername(username)
-			.orElseThrow(() -> new IllegalArgumentException("해당 아이디의 회원을 찾을 수 없습니다."));
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "해당 아이디의 회원을 찾을 수 없습니다."));
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -55,7 +55,7 @@ public class ProgramController {
 
 	@PostMapping("/{programId}")
 	@ResponseStatus(value = HttpStatus.CREATED)
-	public ProgramRegistrationResponseDto applyProgram(@PathVariable Long programId,
+	public ProgramRegistrationResponseDto registerProgram(@PathVariable Long programId,
 		@RequestBody @Valid ProgramRegistrationRequestDto requestDto) {
 		Registration savedRegistration = programService.registerProgram(programId, requestDto);
 		return ProgramRegistrationResponseDto.from(savedRegistration);

--- a/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramRegisteredResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramRegisteredResponseDto.java
@@ -5,7 +5,7 @@ import java.util.List;
 import com.efub.dhs.domain.program.dto.GoalDto;
 import com.efub.dhs.domain.program.dto.PageInfoDto;
 import com.efub.dhs.domain.program.entity.Program;
-import com.efub.dhs.domain.registration.entity.RefundStatus;
+import com.efub.dhs.domain.registration.entity.Registration;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,17 +14,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ProgramRegisteredResponseDto {
 
-	private List<ProgramOutlineWithStatusDto> programs;
+	private List<ProgramOutlineWithRegistrationDto> programs;
 	private PageInfoDto pageInfo;
 
 	@Getter
-	public static class ProgramOutlineWithStatusDto extends ProgramOutlineResponseDto {
-		private final RefundStatus refundStatus;
+	public static class ProgramOutlineWithRegistrationDto extends ProgramOutlineResponseDto {
+		private final ProgramRegistrationResponseDto registrationInfoDto;
 
-		public ProgramOutlineWithStatusDto(
-			Program program, Integer remainingDays, GoalDto goal, Boolean hasLike, RefundStatus refundStatus) {
+		public ProgramOutlineWithRegistrationDto(
+			Program program, Integer remainingDays, GoalDto goal, Boolean hasLike, Registration registration) {
 			super(program, remainingDays, goal, hasLike);
-			this.refundStatus = refundStatus;
+			this.registrationInfoDto = ProgramRegistrationResponseDto.from(registration);
 		}
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramRegistrationResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramRegistrationResponseDto.java
@@ -1,32 +1,43 @@
 package com.efub.dhs.domain.program.dto.response;
 
-import com.efub.dhs.domain.program.dto.request.ProgramRegistrationRequestDto;
+import java.time.LocalDateTime;
+
+import com.efub.dhs.domain.registration.entity.RefundStatus;
 import com.efub.dhs.domain.registration.entity.Registration;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProgramRegistrationResponseDto {
 
 	private long registrationId;
-	private ProgramRegistrationRequestDto registrationInfo;
+	private String depositorName;
+	private String depositAmount;
+	private LocalDateTime depositDate;
+	private String registrantName;
+	private String registrantPhone;
+	private String refundBank;
+	private String refundAccount;
+	private String refundName;
+	private String refundStatus;
 
 	public static ProgramRegistrationResponseDto from(Registration registration) {
-		return new ProgramRegistrationResponseDto(
-			registration.getRegistrationId(),
-			ProgramRegistrationRequestDto.builder()
-				.depositorName(registration.getDepositName())
-				.depositAmount(registration.getDepositAmount())
-				.depositDate(registration.getDepositDate())
-				.registrantName(registration.getRegistrantName())
-				.registrantPhone(registration.getRegistrantPhone())
-				.refundBank(registration.getRefundBank())
-				.refundAccount(registration.getRefundAccount())
-				.refundName(registration.getRefundName())
-				.build()
-		);
+		return ProgramRegistrationResponseDto.builder()
+			.registrationId(registration.getRegistrationId())
+			.depositorName(registration.getDepositName())
+			.depositAmount(registration.getDepositAmount())
+			.depositDate(registration.getDepositDate())
+			.registrantName(registration.getRegistrantName())
+			.registrantPhone(registration.getRegistrantPhone())
+			.refundBank(registration.getRefundBank())
+			.refundAccount(registration.getRefundAccount())
+			.refundName(registration.getRefundName())
+			.refundStatus(RefundStatus.to(registration.getRefundStatus()))
+			.build();
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/entity/Category.java
+++ b/src/main/java/com/efub/dhs/domain/program/entity/Category.java
@@ -2,6 +2,9 @@ package com.efub.dhs.domain.program.entity;
 
 import java.util.Arrays;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -19,7 +22,7 @@ public enum Category {
 		return Arrays.stream(Category.values())
 			.filter(category -> category.name.equals(name))
 			.findFirst()
-			.orElseThrow(() -> new IllegalArgumentException("Invalid Category name: " + name));
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid Category name: " + name));
 	}
 
 	public static String to(Category category) {

--- a/src/main/java/com/efub/dhs/domain/program/entity/Program.java
+++ b/src/main/java/com/efub/dhs/domain/program/entity/Program.java
@@ -121,4 +121,12 @@ public class Program extends BaseTimeEntity {
 			.collect(Collectors.toList());
 		this.notices = List.of();
 	}
+
+	public void increaseRegistrantNumber() {
+		this.registrantNumber++;
+	}
+
+	public void decreaseRegistrantNumber() {
+		this.registrantNumber--;
+	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramMemberService.java
@@ -62,20 +62,20 @@ public class ProgramMemberService {
 		Page<Registration> registrationPage = registrationRepository.findRegisteredPrograms(
 			currentUser, PageRequest.of(page, PAGE_SIZE));
 		PageInfoDto pageInfoDto = PageInfoDto.createRegistrationPageInfoDto(registrationPage);
-		List<ProgramOutlineWithStatusDto> programOutlineWithStatusDtoList =
-			convertToProgramOutlineWithStatusDtoList(registrationPage.getContent(), currentUser);
-		return new ProgramRegisteredResponseDto(programOutlineWithStatusDtoList, pageInfoDto);
+		List<ProgramOutlineWithRegistrationDto> programOutlineWithRegistrationDtoList =
+			convertToProgramOutlineWithRegistrationDtoList(registrationPage.getContent(), currentUser);
+		return new ProgramRegisteredResponseDto(programOutlineWithRegistrationDtoList, pageInfoDto);
 	}
 
-	public List<ProgramOutlineWithStatusDto> convertToProgramOutlineWithStatusDtoList(
+	public List<ProgramOutlineWithRegistrationDto> convertToProgramOutlineWithRegistrationDtoList(
 		List<Registration> registrationList, Member member) {
 		return registrationList.stream().map(registration -> {
 			Program program = registration.getProgram();
-			return new ProgramOutlineWithStatusDto(program,
+			return new ProgramOutlineWithRegistrationDto(program,
 				programService.calculateRemainingDays(program.getDeadline()),
 				programService.findGoalByProgram(program.getTargetNumber(), program.getRegistrantNumber()),
 				heartService.existsByMemberAndProgram(member, program),
-				registration.getRefundStatus());
+				registration);
 		}).collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -7,8 +7,10 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.efub.dhs.domain.heart.service.HeartService;
 import com.efub.dhs.domain.member.entity.Member;
@@ -53,7 +55,7 @@ public class ProgramService {
 
 	public Program getProgram(Long programId) {
 		return programRepository.findById(programId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 ID의 행사를 찾을 수 없습니다."));
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "해당 ID의 행사를 찾을 수 없습니다." + programId));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -141,7 +141,9 @@ public class ProgramService {
 		Member currentUser = memberService.getCurrentUser();
 		Program program = getProgram(programId);
 		Registration registration = requestDto.toEntity(currentUser, program);
-		return registrationService.saveRegistration(registration);
+		Registration savedRegistration = registrationService.saveRegistration(registration);
+		program.increaseRegistrantNumber();
+		return savedRegistration;
 	}
 
 	public ProgramListResponseDto findProgramList(int page, ProgramListRequestDto requestDto) {

--- a/src/main/java/com/efub/dhs/domain/registration/controller/RegistrationController.java
+++ b/src/main/java/com/efub/dhs/domain/registration/controller/RegistrationController.java
@@ -1,11 +1,14 @@
 package com.efub.dhs.domain.registration.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.efub.dhs.domain.program.dto.response.ProgramRegistrationResponseDto;
+import com.efub.dhs.domain.registration.dto.RegistrationModificationRequestDto;
 import com.efub.dhs.domain.registration.entity.Registration;
 import com.efub.dhs.domain.registration.service.RegistrationService;
 
@@ -22,5 +25,12 @@ public class RegistrationController {
 	public ProgramRegistrationResponseDto findRegistration(@PathVariable Long registrationId) {
 		Registration registration = registrationService.findRegistration(registrationId);
 		return ProgramRegistrationResponseDto.from(registration);
+	}
+
+	@PatchMapping("/{registrationId}")
+	public ProgramRegistrationResponseDto modifyRegistration(
+		@PathVariable Long registrationId, @RequestBody RegistrationModificationRequestDto requestDto) {
+		Registration modifiedRegistration = registrationService.modifyRegistration(registrationId, requestDto);
+		return ProgramRegistrationResponseDto.from(modifiedRegistration);
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/registration/controller/RegistrationController.java
+++ b/src/main/java/com/efub/dhs/domain/registration/controller/RegistrationController.java
@@ -1,0 +1,26 @@
+package com.efub.dhs.domain.registration.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.efub.dhs.domain.program.dto.response.ProgramRegistrationResponseDto;
+import com.efub.dhs.domain.registration.entity.Registration;
+import com.efub.dhs.domain.registration.service.RegistrationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/registrations")
+public class RegistrationController {
+
+	private final RegistrationService registrationService;
+
+	@GetMapping("/{registrationId}")
+	public ProgramRegistrationResponseDto findRegistration(@PathVariable Long registrationId) {
+		Registration registration = registrationService.findRegistration(registrationId);
+		return ProgramRegistrationResponseDto.from(registration);
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/registration/dto/RegistrationModificationRequestDto.java
+++ b/src/main/java/com/efub/dhs/domain/registration/dto/RegistrationModificationRequestDto.java
@@ -1,0 +1,17 @@
+package com.efub.dhs.domain.registration.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RegistrationModificationRequestDto {
+
+	private String registrantName;
+	private String registrantPhone;
+	private String refundBank;
+	private String refundAccount;
+	private String refundName;
+	private String refundStatus;
+}

--- a/src/main/java/com/efub/dhs/domain/registration/entity/RefundStatus.java
+++ b/src/main/java/com/efub/dhs/domain/registration/entity/RefundStatus.java
@@ -2,6 +2,9 @@ package com.efub.dhs.domain.registration.entity;
 
 import java.util.Arrays;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -16,7 +19,8 @@ public enum RefundStatus {
 		return Arrays.stream(RefundStatus.values())
 			.filter(refundStatus -> refundStatus.name.equals(name))
 			.findFirst()
-			.orElseThrow(() -> new IllegalArgumentException("Invalid RefundStatus name: " + name));
+			.orElseThrow(
+				() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid RefundStatus name: " + name));
 	}
 
 	public static String to(RefundStatus refundStatus) {

--- a/src/main/java/com/efub/dhs/domain/registration/entity/Registration.java
+++ b/src/main/java/com/efub/dhs/domain/registration/entity/Registration.java
@@ -14,6 +14,7 @@ import javax.persistence.ManyToOne;
 
 import com.efub.dhs.domain.member.entity.Member;
 import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.registration.dto.RegistrationModificationRequestDto;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -83,5 +84,27 @@ public class Registration {
 		this.refundBank = refundBank;
 		this.refundAccount = refundAccount;
 		this.refundName = refundName;
+	}
+
+	public Registration modifyRegistration(RegistrationModificationRequestDto requestDto) {
+		if (requestDto.getRegistrantName() != null) {
+			this.registrantName = requestDto.getRegistrantName();
+		}
+		if (requestDto.getRegistrantPhone() != null) {
+			this.registrantPhone = requestDto.getRegistrantPhone();
+		}
+		if (requestDto.getRefundBank() != null) {
+			this.refundBank = requestDto.getRefundBank();
+		}
+		if (requestDto.getRefundAccount() != null) {
+			this.refundAccount = requestDto.getRefundAccount();
+		}
+		if (requestDto.getRefundName() != null) {
+			this.refundName = requestDto.getRefundName();
+		}
+		if (requestDto.getRefundStatus() != null) {
+			this.refundStatus = RefundStatus.from(requestDto.getRefundStatus());
+		}
+		return this;
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
+++ b/src/main/java/com/efub/dhs/domain/registration/service/RegistrationService.java
@@ -36,6 +36,17 @@ public class RegistrationService {
 	}
 
 	@Transactional(readOnly = true)
+	public Registration findRegistration(Long registrationId) {
+		Registration registration = registrationRepository.findById(registrationId)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
+		Member currentUser = memberService.getCurrentUser();
+		if (!currentUser.equals(registration.getMember())) {
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+		}
+		return registration;
+	}
+
+	@Transactional(readOnly = true)
 	public List<RegistrationResponseDto> findRegistratorList(Program program) {
 		Member member = memberService.getCurrentUser();
 		if (member.equals(program.getHost())) {

--- a/src/main/java/com/efub/dhs/global/config/SecurityConfig.java
+++ b/src/main/java/com/efub/dhs/global/config/SecurityConfig.java
@@ -33,12 +33,9 @@ public class SecurityConfig {
 			.and()
 			.authorizeRequests()
 			.antMatchers(HttpMethod.OPTIONS).permitAll()
-			.antMatchers("/programs/created",
-				"/programs/liked",
-				"/programs/registered",
-				"/auth/logout").authenticated()
+			.antMatchers("/programs/created", "/programs/liked", "/programs/registered", "/auth/logout").authenticated()
 			.antMatchers("/auth/**", "/oauth/**").permitAll()
-			.antMatchers(HttpMethod.GET, "/programs", "/programs/*").permitAll()
+			.antMatchers(HttpMethod.GET, "/docs", "/swagger-ui/**", "/programs", "/programs/*").permitAll()
 			.anyRequest().authenticated()
 			.and()
 			.addFilterBefore(new JwtFilter(jwtAuthProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/efub/dhs/global/jwt/service/JwtService.java
+++ b/src/main/java/com/efub/dhs/global/jwt/service/JwtService.java
@@ -36,6 +36,6 @@ public class JwtService {
 
 	private JwtToken getJwtToken(String accessToken) {
 		return jwtRepository.findByAccessToken(accessToken)
-			.orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid Access Token."));
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid Access Token."));
 	}
 }

--- a/src/main/java/com/efub/dhs/global/utils/SecurityUtils.java
+++ b/src/main/java/com/efub/dhs/global/utils/SecurityUtils.java
@@ -1,16 +1,16 @@
 package com.efub.dhs.global.utils;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.server.ResponseStatusException;
 
 public class SecurityUtils {
 
 	public static String getCurrentUsername() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		if (authentication == null || authentication.getName() == null) {
-			throw new AuthenticationException("There is no authentication information for the current user.") {
-			};
+			throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "There is no authentication information.");
 		}
 		return authentication.getName();
 	}


### PR DESCRIPTION
## 📣 Description

행사 참가 신청 관련 API들 수정하고 추가했습니다.
 - 행사 참가 신청 시 Program의 registrantNum을 1 증가시키는 코드 추가
 - 신청한 행사 리스트 조회 API 응답에 Registration 정보도 추가
 - 신청 정보 개별 조회 API 추가
 - 신청 정보 수정 API 추가

Registration DTO 통일하려고 했는데 신청한 행사 리스트 조회의 응답이 뎁스가 너무 많아지는 것 같기도 해서 일단 제가 쓰고 있던 걸로 통일했습니다. 그리고 신청 정보 수정은 신청자 이름, 전화 번호, 환불 정보만 수정할 수 있도록 했는데 입금 정보 수정도 필요할까요?? 이런 폼 제출할 때 입금 정보는 대체로 수정하지 못했던 것 같아서 일단은 이렇게 했습니다.
편하게 피드백 주세용~

Issue Number: #44

## 📸 Screenshot

- 행사 신청 API
<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/c2147747-098b-46bb-9ae7-8c127269025c">

- 행사 신청 전 registrantNum
<img width="500" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/6c91893e-cf29-47df-8898-226e04db7a47">

- 행사 신청 후 registrantNum
<img width="500" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/5c9c7daf-a2f5-4e73-a231-f84a7e062546">

- 신청한 행사 리스트 조회 API
<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/732cb480-2640-4df9-a592-4d7f0f30840c">

- 신청 정보 개별 조회 API
<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/7676c588-bf6c-4c28-bc99-5018833e3c66">

- 신청 정보 수정 API
<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/fd51059b-1c69-4e5d-9b28-1b26c0e67526">

## 📝 ETC
