### PR TITLE
[FEAT] S3 이미지 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ dependencies {
     // querydsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+    // aws
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
+++ b/src/main/java/com/efub/dhs/domain/program/controller/ProgramController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,8 +13,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.efub.dhs.domain.program.dto.request.NoticeCreationRequestDto;
 import com.efub.dhs.domain.program.dto.request.ProgramCreationRequestDto;
@@ -27,7 +30,9 @@ import com.efub.dhs.domain.program.dto.response.ProgramOutlineResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramRegisteredResponseDto;
 import com.efub.dhs.domain.program.dto.response.ProgramRegistrationResponseDto;
 import com.efub.dhs.domain.program.entity.Program;
+import com.efub.dhs.domain.program.entity.ProgramImage;
 import com.efub.dhs.domain.program.service.NoticeService;
+import com.efub.dhs.domain.program.service.ProgramImageService;
 import com.efub.dhs.domain.program.service.ProgramMemberService;
 import com.efub.dhs.domain.program.service.ProgramService;
 import com.efub.dhs.domain.registration.dto.RegistrationResponseDto;
@@ -35,7 +40,9 @@ import com.efub.dhs.domain.registration.entity.Registration;
 import com.efub.dhs.domain.registration.service.RegistrationService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/programs")
@@ -45,6 +52,7 @@ public class ProgramController {
 	private final ProgramMemberService programMemberService;
 	private final RegistrationService registrationService;
 	private final NoticeService noticeService;
+	private final ProgramImageService programImageService;
 
 	@GetMapping("/{programId}")
 	@ResponseStatus(value = HttpStatus.OK)
@@ -52,10 +60,14 @@ public class ProgramController {
 		return programService.findProgramById(programId);
 	}
 
-	@PostMapping
+	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@ResponseStatus(value = HttpStatus.CREATED)
-	public ProgramCreationResponseDto createProgram(@RequestBody @Valid ProgramCreationRequestDto requestDto) {
-		return new ProgramCreationResponseDto(programService.createProgram(requestDto));
+	public ProgramCreationResponseDto createProgram(
+		@RequestPart(value = "data") @Valid ProgramCreationRequestDto requestDto,
+		@RequestPart(value = "image") List<MultipartFile> images) {
+		List<ProgramImage> programImages = programImageService.createProgramImages(images);
+		Long programId = programService.createProgram(requestDto, programImages);
+		return new ProgramCreationResponseDto(programId);
 	}
 
 	@PostMapping("/{programId}")

--- a/src/main/java/com/efub/dhs/domain/program/dto/request/ProgramCreationRequestDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/request/ProgramCreationRequestDto.java
@@ -1,10 +1,8 @@
 package com.efub.dhs.domain.program.dto.request;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import com.efub.dhs.domain.member.entity.Member;
@@ -47,8 +45,6 @@ public class ProgramCreationRequestDto {
 	private String hostName;
 	@NotBlank
 	private String hostDescription;
-	@NotEmpty
-	private List<String> images;
 
 	public Program toEntity(Member member) {
 		return Program.builder()
@@ -67,7 +63,6 @@ public class ProgramCreationRequestDto {
 			.price(price)
 			.hostName(hostName)
 			.hostDescription(hostDescription)
-			.imageUrlList(images)
 			.build();
 	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/entity/Program.java
+++ b/src/main/java/com/efub/dhs/domain/program/entity/Program.java
@@ -2,7 +2,6 @@ package com.efub.dhs.domain.program.entity;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -97,7 +96,7 @@ public class Program extends BaseTimeEntity {
 	public Program(Member host, String title, Category category, LocalDateTime schedule, String location,
 		String postalCode, LocalDateTime deadline, Integer targetNumber, String content, String depositBank,
 		String depositName, String depositAccount, String price, String hostName,
-		String hostDescription, List<String> imageUrlList) {
+		String hostDescription) {
 		this.host = host;
 		this.title = title;
 		this.category = category;
@@ -116,9 +115,6 @@ public class Program extends BaseTimeEntity {
 		this.price = price;
 		this.hostDescription = hostDescription;
 		this.hostName = hostName;
-		this.images = imageUrlList.stream()
-			.map(url -> ProgramImage.builder().program(this).url(url).build())
-			.collect(Collectors.toList());
 		this.notices = List.of();
 	}
 
@@ -128,8 +124,8 @@ public class Program extends BaseTimeEntity {
 
 	public void decreaseRegistrantNumber() {
 		this.registrantNumber--;
-  }
-  
+	}
+
 	public void closeProgram() {
 		this.isOpen = false;
 	}

--- a/src/main/java/com/efub/dhs/domain/program/entity/ProgramImage.java
+++ b/src/main/java/com/efub/dhs/domain/program/entity/ProgramImage.java
@@ -33,4 +33,8 @@ public class ProgramImage {
 		this.program = program;
 		this.url = url;
 	}
+
+	public void setProgram(Program program) {
+		this.program = program;
+	}
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramImageService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramImageService.java
@@ -1,0 +1,56 @@
+package com.efub.dhs.domain.program.service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.efub.dhs.domain.program.entity.ProgramImage;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProgramImageService {
+
+	private final AmazonS3 amazonS3;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	private String uploadImageToS3(MultipartFile imageFile) throws IOException {
+		ObjectMetadata metadata = new ObjectMetadata();
+		metadata.setContentLength(imageFile.getSize());
+		metadata.setContentType(imageFile.getContentType());
+
+		String filename = UUID.randomUUID().toString();
+		PutObjectRequest putObjectRequest =
+			new PutObjectRequest(bucket, filename, imageFile.getInputStream(), metadata)
+				.withCannedAcl(CannedAccessControlList.PublicRead);
+		amazonS3.putObject(putObjectRequest);
+
+		return amazonS3.getUrl(bucket, filename).toString();
+	}
+
+	public List<ProgramImage> createProgramImages(List<MultipartFile> images) {
+		return images.stream().map(image -> {
+			String imageUrl;
+			try {
+				imageUrl = uploadImageToS3(image);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+			return ProgramImage.builder()
+				.url(imageUrl)
+				.build();
+		}).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -130,13 +130,15 @@ public class ProgramService {
 		).collect(Collectors.toList());
 	}
 
-	public Long createProgram(ProgramCreationRequestDto requestDto) {
+	public Long createProgram(ProgramCreationRequestDto requestDto, List<ProgramImage> programImages) {
 		Member currentUser = memberService.getCurrentUser();
 		Program program = requestDto.toEntity(currentUser);
-		Long programId = programRepository.save(program).getProgramId();
-		List<ProgramImage> images = program.getImages();
-		programImageRepository.saveAll(images);
-		return programId;
+		Program savedProgram = programRepository.save(program);
+		for (ProgramImage programImage : programImages) {
+			programImage.setProgram(savedProgram);
+			programImageRepository.save(programImage);
+		}
+		return savedProgram.getProgramId();
 	}
 
 	public ProgramDetailResponseDto closeProgram(Long programId) {

--- a/src/main/java/com/efub/dhs/global/config/S3Config.java
+++ b/src/main/java/com/efub/dhs/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.efub.dhs.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3Client amazonS3Client() {
+		BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+		return (AmazonS3Client)AmazonS3ClientBuilder
+			.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(credentials))
+			.build();
+	}
+}


### PR DESCRIPTION
## 📣 Description

행사 등록 시 S3에 이미지를 업로드하는 로직을 추가했습니다.

행사 등록 API에 이미지를 String으로 받던 것을
이제 MultipartFile 형식으로 받아서 S3에 업로드한 후 생성된 URL을 DB에 저장합니다.

Issue Number: solved #49 

## 📸 Screenshot

- 요청은 `form-data` 형식으로 아래와 같은 구조로 받습니다.
<img width="700" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/5c9cd342-8ece-4ee4-ba39-70367fc49dca">
<img width="550" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/63b96f97-33f8-4b15-b0fe-c67b20f2cc4c">


- S3 업로드 (파일 이름은 중복 방지를 위해 UUID로 랜덤 생성합니다)
<img width="600" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/5d812f9e-a7bc-410d-8580-cbd85a663fa0">


- DB에는 이미지의 URL만 저장됩니다.
<img width="700" alt="image" src="https://github.com/TEAM-DHS/dhs-server/assets/71026706/fd87f77d-9b82-4c44-a9c1-e768903983ca">


## 📝 ETC
