### PR TITLE
[FIX] 비슷한 행사 리스트, 인기 행사 리스트 로직 수정

### DIFF
--- a/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramOutlineResponseDto.java
+++ b/src/main/java/com/efub/dhs/domain/program/dto/response/ProgramOutlineResponseDto.java
@@ -16,6 +16,7 @@ public class ProgramOutlineResponseDto {
 	private String category;
 	private String thumbnailImage;
 	private Integer remainingDays;
+	private Long likeNumber;
 	private Boolean isOpen;
 	private GoalDto goal;
 	private String content;
@@ -27,6 +28,7 @@ public class ProgramOutlineResponseDto {
 		this.category = Category.to(program.getCategory());
 		this.thumbnailImage = program.getImages().get(0).getUrl();
 		this.remainingDays = remainingDays;
+		this.likeNumber = program.getLikeNumber();
 		this.isOpen = program.getIsOpen();
 		this.goal = goal;
 		this.content = program.getContent();

--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
@@ -20,6 +20,6 @@ public interface ProgramRepository extends JpaRepository<Program, Long>, Program
 
 	@Query(value = "select p from Program p join fetch Heart h on h.program=p where h.member=?1")
 	Page<Program> findAllProgramLiked(Member member, Pageable pageable);
-	
-	List<Program> findTop5ByOrderByLikeNumberDesc();
+
+	List<Program> findTop5ByIsOpenOrderByLikeNumberDesc(Boolean isOpen);
 }

--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
@@ -13,8 +13,7 @@ import com.efub.dhs.domain.program.entity.Program;
 
 public interface ProgramRepository extends JpaRepository<Program, Long>, ProgramRepositoryCustom {
 
-	//List<Program> findTop3ByCategoryAndScheduleMonth(Category category, Month month);
-	List<Program> findTop3ByCategory(Category category);
+	List<Program> findAllByCategoryAndIsOpenOrderByDeadlineAsc(Category category, Boolean isOpen);
 
 	Page<Program> findAllByHost(Member host, Pageable pageable);
 

--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
@@ -21,5 +21,5 @@ public interface ProgramRepository extends JpaRepository<Program, Long>, Program
 	@Query(value = "select p from Program p join fetch Heart h on h.program=p where h.member=?1")
 	Page<Program> findAllProgramLiked(Member member, Pageable pageable);
 
-	List<Program> findTop5ByIsOpenOrderByLikeNumberDesc(Boolean isOpen);
+	List<Program> findAllByIsOpenOrderByLikeNumberDesc(Boolean isOpen);
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -2,6 +2,7 @@ package com.efub.dhs.domain.program.service;
 
 import java.time.LocalDateTime;
 import java.time.Period;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -190,13 +191,21 @@ public class ProgramService {
 	}
 
 	public List<ProgramOutlineResponseDto> findProgramPopular() {
-		List<Program> programList = programRepository.findTop5ByOrderByLikeNumberDesc();
-		return programList.stream().map(program ->
-			new ProgramOutlineResponseDto(program,
-				calculateRemainingDays(program.getDeadline()),
-				findGoalByProgram(program.getTargetNumber(), program.getRegistrantNumber()),
-				false)
-		).collect(Collectors.toList());
+		List<Program> programList = programRepository.findAllByIsOpenOrderByLikeNumberDesc(true);
+		List<ProgramOutlineResponseDto> popularProgramList = new ArrayList<>();
+
+		programList.forEach(program -> {
+			if (popularProgramList.size() == 5) {
+				return;
+			}
+			Integer remainingDays = calculateRemainingDays(program.getDeadline());
+			if (remainingDays >= 0) {
+				popularProgramList.add(new ProgramOutlineResponseDto(program, remainingDays,
+					findGoalByProgram(program.getTargetNumber(), program.getRegistrantNumber()),
+					false));
+			}
+		});
+		return popularProgramList;
 	}
 
 	public Member isLoggedIn(String username) {


### PR DESCRIPTION
## 📣 Description

비슷한 행사 기준 변경: 진행 중, 동일 카테고리, 마감임박순 3개 (+ 현재 행사 제외)
인기 행사 기준 변경: 진행 중, 좋아요순 5개

원래 Repository에서 Top 키워드를 이용해서 상위 3개, 5개를 리스트로 가져왔는데,
행사가 진행 중이라는 조건을 추가하면서 Top 키워드를 버리고 서비스 단에서 필터링을 해주었습니다.

진행 중이란
- `isOpen` == true
- _`remainingDays` >= 0_
사실 `deadline`이 지나면 행사는 자동으로 마감(`isOpen` == false)이 되어야 하는데, 
현재 배치 작업까지는 할 시간이 없기 때문에 자동으로 마감이 되지 않고 있습니다.
따라서 두번째 조건을 추가해주었습니다.


Issue Number: solved #54 

## 📸 Screenshot

- 8번 행사의 비슷한 행사 조회 시 6, 7, 9번 행사 반환 (현재 행사(8)가 제외됨)
<img width="681" alt="스크린샷 2023-11-26 오전 2 43 45" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/e17b6dd0-b35c-462e-b436-4fb6cc98cefe">

<img width="681" alt="스크린샷 2023-11-26 오전 2 43 50" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/3ad2d706-af3d-4e2f-bdaf-1135a2728a67">

- 인기 행사 조회 시 5, 2, 3, 6, 7번 행사 반환 ('진행 중' 조건 넣지 않았을 때는, 마감 상태였던 1번이 리스트에 포함되었음)
<img width="681" alt="스크린샷 2023-11-26 오전 2 46 28" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/8e4eeb3f-a25d-4749-b34a-0015d9eca301">

<img width="681" alt="스크린샷 2023-11-26 오전 2 46 35" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/6a77ea3e-759b-4436-930a-b302d3cffc63">

<img width="681" alt="스크린샷 2023-11-26 오전 2 46 38" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/474a8e83-ffab-4240-9b49-0dcfd095e9c0">





## 📝 ETC