### PR TITLE
[REFACTOR] 비슷한 행사, 인기 행사 리스트 조회

### DIFF
--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
@@ -1,5 +1,6 @@
 package com.efub.dhs.domain.program.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -13,7 +14,8 @@ import com.efub.dhs.domain.program.entity.Program;
 
 public interface ProgramRepository extends JpaRepository<Program, Long>, ProgramRepositoryCustom {
 
-	List<Program> findAllByCategoryAndIsOpenOrderByDeadlineAsc(Category category, Boolean isOpen);
+	List<Program> findTop3ByCategoryAndIsOpenAndDeadlineAfterAndProgramIdNotOrderByDeadlineAsc(Category category,
+		Boolean isOpen, LocalDateTime deadline, Long programId);
 
 	Page<Program> findAllByHost(Member host, Pageable pageable);
 

--- a/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
+++ b/src/main/java/com/efub/dhs/domain/program/repository/ProgramRepository.java
@@ -22,5 +22,5 @@ public interface ProgramRepository extends JpaRepository<Program, Long>, Program
 	@Query(value = "select p from Program p join fetch Heart h on h.program=p where h.member=?1")
 	Page<Program> findAllProgramLiked(Member member, Pageable pageable);
 
-	List<Program> findAllByIsOpenOrderByLikeNumberDesc(Boolean isOpen);
+	List<Program> findTop5ByIsOpenAndDeadlineAfterOrderByLikeNumberDesc(Boolean isOpen, LocalDateTime deadline);
 }

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -127,12 +127,9 @@ public class ProgramService {
 
 	public List<ProgramOutlineResponseDto> findSimilarPrograms(Program program, Member member) {
 		List<Program> similarProgramList =
-			programRepository.findAllByCategoryAndIsOpenOrderByDeadlineAsc(program.getCategory(), true);
-		similarProgramList.remove(program);
-
-		List<Program> filteredSimilarProgramList = getProgramByRemainingDays(similarProgramList, 3);
-
-		return convertToProgramOutlineResponseDtoList(filteredSimilarProgramList, member);
+			programRepository.findTop3ByCategoryAndIsOpenAndDeadlineAfterAndProgramIdNotOrderByDeadlineAsc(
+				program.getCategory(), true, LocalDateTime.now(), program.getProgramId());
+		return convertToProgramOutlineResponseDtoList(similarProgramList, member);
 	}
 
 	public List<ProgramOutlineResponseDto> convertToProgramOutlineResponseDtoList(

--- a/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
+++ b/src/main/java/com/efub/dhs/domain/program/service/ProgramService.java
@@ -2,7 +2,6 @@ package com.efub.dhs.domain.program.service;
 
 import java.time.LocalDateTime;
 import java.time.Period;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -192,25 +191,9 @@ public class ProgramService {
 	}
 
 	public List<ProgramOutlineResponseDto> findProgramPopular() {
-		List<Program> popularProgramList = programRepository.findAllByIsOpenOrderByLikeNumberDesc(true);
-		List<Program> filteredPopularProgramList = getProgramByRemainingDays(popularProgramList, 5);
-		return convertToProgramOutlineResponseDtoList(filteredPopularProgramList, null);
-	}
-
-	public List<Program> getProgramByRemainingDays(List<Program> programList, int size) {
-		List<Program> filteredList = new ArrayList<>();
-
-		programList.forEach(program -> {
-			if (filteredList.size() == size) {
-				return;
-			}
-			Integer remainingDays = calculateRemainingDays(program.getDeadline());
-			if (remainingDays >= 0) {
-				filteredList.add(program);
-			}
-		});
-
-		return filteredList;
+		List<Program> popularProgramList =
+			programRepository.findTop5ByIsOpenAndDeadlineAfterOrderByLikeNumberDesc(true, LocalDateTime.now());
+		return convertToProgramOutlineResponseDtoList(popularProgramList, null);
 	}
 
 	public Member isLoggedIn(String username) {


### PR DESCRIPTION
## 📣 Description

저번 리뷰를 받고 레포지토리에서 쿼리를 모두 구현하여 서비스 단까지 넘어오지 않게 할 수 있는 방법이 없는지 열심히 찾아보았습니다.
그리고 해냈습니다!

우선 이전 방식에서는 `isOpen` == true, remainingDays >= 0 조건으로 필터링을 했었습니다.

그러나 새로운 방식에서는 `isOpen` == true, `deadline` > now() 조건을 JPA query method에서 직접 처리하도록 변경하였습니다.
- DeadlineAfter 사용

그리고 비슷한 행사의 경우, 현재 행사를 제외하는 것도 JPA query method에서 처리하도록 변경하였습니다.
- ProgramIdNot 사용

Issue Number: solved #64

## 📸 Screenshot

- 비슷한 행사 리스트: 6, 7, 9 (현재 행사 8은 제외됨)
<img width="681" alt="스크린샷 2023-11-27 오전 12 33 05" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/9794153e-7e35-4acc-b1ba-534bcd0edbbf">
<img width="681" alt="스크린샷 2023-11-27 오전 12 33 09" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/abd53aef-22ea-4963-91d0-0f07ec13b5f8">

- 인기 행사 리스트: 5, 2, 6, 7, 8
- 좋아요 순으로 정렬 시 5, 2, 4, 3, 1, 6, 7, 8 이지만, 4, 3은 deadline이 지났고 1은 isOpen==true입니다.
<img width="681" alt="스크린샷 2023-11-27 오전 12 32 46" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/f350a60a-b429-4266-b90c-4e8401891cdb">
<img width="681" alt="스크린샷 2023-11-27 오전 12 32 53" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/b7efbd10-5405-4b31-b044-599e4f9ffbdc">
<img width="681" alt="스크린샷 2023-11-27 오전 12 32 00" src="https://github.com/TEAM-DHS/dhs-server/assets/121334671/1a3787b6-2347-4749-b329-93e283b3767c">


## 📝 ETC